### PR TITLE
Ensure Debian packages dependencies compatibility

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -305,7 +305,7 @@ nfpms:
     formats:
       - deb
     dependencies:
-      - containerd.io
+      - containerd.io | containerd
       - mosquitto
     scripts:
       postinstall: "build/postinst"


### PR DESCRIPTION
1. Added containerd package alternative to cover packages coming from:
  > Docker repos (prior to Debian Bullseye)
  > Debian repos (Byllseye and newer)

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>