### PR TITLE
Update the website's base URL

### DIFF
--- a/web/site/config.toml
+++ b/web/site/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://www.websites.eclipseprojects.io/kanto/"
+baseURL = "https://websites.eclipseprojects.io/kanto/"
 title = "Eclipse Kanto™ | IoT edge software stack"
 
 enableRobotsTXT = true


### PR DESCRIPTION
[#28] The new website's base URL is updated not to be www-prefixed any more

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>