### PR TITLE
Provide Reference guide for Kanto Software Update

### DIFF
--- a/web/site/content/docs/references/_index.md
+++ b/web/site/content/docs/references/_index.md
@@ -1,0 +1,7 @@
+---
+title: "References"
+type: docs
+description: >
+  Explore customization of key essentials of Eclipse Kanto.
+weight: 5
+---

--- a/web/site/content/docs/references/software-update-config.md
+++ b/web/site/content/docs/references/software-update-config.md
@@ -1,0 +1,64 @@
+---
+title: "Software update configuration"
+type: docs
+description: >
+  Customize the deployment and management of software artifacts.
+weight: 3
+---
+
+### Properties
+
+To control all aspects of the software update behavior.
+
+| Property | Type | Default | Description |
+| - | - | - | - |
+| featureId | string | SoftwareUpdatable | Feature unique identifier in the scope of the edge digital twin |
+| moduleType | string | software | Type of the software that is managed by this feature |
+| artifactType | string | archive | Type of the artifact that is to be processed: archive or plain |
+| install | string[] | | Absolute path to the install script/command and an optional sequence of additional flags/parameters |
+| storageLocation | string | ./ | Path to the storage directory where the working files are stored |
+| **Local connectivity** | | | |
+| broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the software update will connect for the local communication, the format is: `scheme://host:port` |
+| username | string | | Username that is a part of the credentials |
+| password | string | | Password that is a part of the credentials |
+| **Logging** | | | |
+| logFile | string | log/software-update.log | Path to the file where log messages are written |
+| logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
+| logFileCount | int | 5 | Log file maximum rotations count |
+| logFileMaxAge | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files |
+| logFileSize | int | 2 | Log file size in MB before it gets rotated |
+
+### Example
+
+The minimal required configuration that sets the software type to firmware.
+
+```json
+{
+    "moduleType": "firmware",
+    "storageLocation": "/var/lib/software-update",
+    "logFile": "/var/log/software-update/software-update.log"
+}
+```
+
+### Template
+
+The configuration can be further adjusted according to the use case.
+The following template illustrates all possible properties with their default values.
+
+```json
+{
+    "featureId": "SoftwareUpdatable",
+    "moduleType": "software",
+    "artifactType": "archive",
+    "install": [],
+    "storageLocation": "./",
+    "broker": "tcp://localhost:1883",
+    "username": "",
+    "password": "",
+    "logFile": "log/software-update.log",
+    "logLevel": "INFO",
+    "logFileCount": 5,
+    "logFileMaxAge": 28,
+    "logFileSize": 2
+}
+```


### PR DESCRIPTION
[#38 ] Provide Reference guide for the Kanto Software Update

- add reference guide section in Eclipse Kanto documentation
- provide relevant information about available configurations

Signed-off-by: Trifonova Antonia <Antonia.Trifonova@bosch.io>