### PR TITLE
Provide Reference guide for the configuration of container instance

### DIFF
--- a/web/site/content/docs/references/containers/_index.md
+++ b/web/site/content/docs/references/containers/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Container management configuration"
+type: docs
+description: >
+  Customize the deployment and management of containers.
+weight: 2
+---

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -59,7 +59,7 @@ To control all aspects of the container instance behavior.
 
 ### Example
 
-The minimal required information to create a container instance is the receptive container image.
+The minimal required configuration to spin up an InfluxDB container instance.
 
 ```json
 {
@@ -74,7 +74,7 @@ The minimal required information to create a container instance is the receptive
 The configuration can be further adjusted according to the use case. The following template illustrates all possible properties with their default values.
 
 {{% warn %}}
-Be aware that some combinations may require property removal.
+Be aware that some combinations may require property removal
 {{% /warn %}}
 
 ```json

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -46,20 +46,20 @@ To control all aspects of the container instance behavior.
 | memory_reservation | string | | Soft memory limitation of the container as a number with a unit suffix of B, K, M and G, if `memory` is specified, the `memory_reservation` must be smaller than it |
 | memory_swap | string | | Total amount of memory and swap that the container can use as a number with a unit suffix of B, K, M and G, use -1 to allow the container to use unlimited swap |
 | **Lifecycle** | | | |
-| type | string | unless-stopped | The container restart policy, the supported types are: always, no, on-failure and unless-stopped |
+| type | string | unless-stopped | The container's restart policy, the supported types are: always, no, on-failure and unless-stopped |
 | maximum_retry_count | int | | Maximum number of retries that are made to restart the container on exit with fail, if the `type` is on-failure |
 | retry_timeout | int | | Timeout period in seconds for each retry that is made to restart the container on exit with fail, if the `type` is on-failure |
 | **Logging** | | | |
 | type | string | json-file | Type in which the logs are produced, the possible options are: json-file or none |
 | max_files | int | 2 | Maximum log files before getting rotated |
 | max_size | string | 100M | Maximum log file size before getting rotated as a number with a unit suffix of B, K, M and G |
-| root_dir | string | <meta_path>/containers/<container_id> | Root directory where the log messages are stored per the container |
+| root_dir | string | <meta_path>/containers/<container_id> | Root directory where the container's log messages are stored |
 | mode | string | blocking | Messaging delivery mode from the container to the log driver, the supported modes are: blocking and non-blocking |
-| max_buffer_size | string | 1M | Maximum buffer size to store the messages for the container as a number with a unit suffix of B, K, M and G |
+| max_buffer_size | string | 1M | Maximum size of the buffered container's log messages in a non-blocking mode as a number with a unit suffix of B, K, M and G |
 
 ### Example
 
-The minimal required information to create the container instance is the receptive container image.
+The minimal required information to create a container instance is the receptive container image.
 
 ```json
 {
@@ -74,7 +74,7 @@ The minimal required information to create the container instance is the recepti
 The configuration can be further adjusted according to the use case. The following template illustrates all possible properties with their default values.
 
 {{% warn %}}
-Be aware that some combinations require property removal.
+Be aware that some combinations may require property removal.
 {{% /warn %}}
 
 ```json

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -47,8 +47,8 @@ To control all aspects of the container instance behavior.
 | memory_swap | string | | Total amount of memory and swap that the container can use as a number with a unit suffix of B, K, M and G, use -1 to allow the container to use unlimited swap |
 | **Lifecycle** | | | |
 | type | string | unless-stopped | Container restart policy, the supported types are: always, no, on-failure and unless-stopped |
-| maximum_retry_count | int | | Maximum number of retries that are made to restart the container on exit |
-| retry_timeout | int | | Timeout period in seconds for each retry that is made to restart the container on exit |
+| maximum_retry_count | int | | Maximum number of retries that are made to restart the container on exit with fail, if the `type` is on-failure |
+| retry_timeout | int | | Timeout period in seconds for each retry that is made to restart the container on exit with fail, if the `type` is on-failure |
 | **Logging** | | | |
 | type | string | json-file | Type in which the logs are produced, the possible options are: json-file or none |
 | max_files | int | 2 | Maximum log files before getting rotated |

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -2,7 +2,7 @@
 title: "Container configuration"
 type: docs
 description: >
-  Customize the deployment of container instance.
+  Customize the deployment of a container instance.
 weight: 2
 ---
 
@@ -37,7 +37,7 @@ To control all aspects of the container instance behavior.
 | **Host resources - mount points** | | | |
 | source | string | | Path to the file or directory on the host that is referred from within the container |
 | destination | string | | Path to the file or directory that is mounted inside the container |
-| propagation_mode | string | rprivate | Propagation mode in which mounts in container are accessible on host, the supported modes are: rprivate, private, rshared, shared, rslave or slave |
+| propagation_mode | string | rprivate | Bind propagation for the mount, supported are: rprivate, private, rshared, shared, rslave or slave |
 | **Process** | | | |
 | env | string[] | | Environment variables that are set into container |
 | cmd | string[] | | Command with arguments that is executed upon container's start |
@@ -54,7 +54,7 @@ To control all aspects of the container instance behavior.
 | max_files | int | 2 | Maximum log files before getting rotated |
 | max_size | string | 100M | Maximum log file size before getting rotated as a number with a unit suffix of B, K, M and G |
 | root_dir | string | <meta_path>/containers/<container_id> | Root directory where the log messages are stored per a container |
-| mode | string | blocking | Messaging delivery mode from the container to log driver, the supported modes are: blocking and non-blocking |
+| mode | string | blocking | Messaging delivery mode from the container to the log driver, the supported modes are: blocking and non-blocking |
 | max_buffer_size | string | 1M | Maximum buffer size to store the messages per container as a number with a unit suffix of B, K, M and G |
 
 ### Example

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -12,59 +12,59 @@ To control all aspects of the container instance behavior.
 
 | Property | Type | Default | Description |
 | - | - | - | - |
-| container_name | string | \<container ID\> | User-defined name of the container |
-| domain_name | string | \<container name\>-domain | Domain name inside the container |
-| host_name | string | \<container name\>-host | Host name for the container  |
+| container_name | string | <container_id> | User-defined name for the container, if omitted the internally auto-generated container ID will be set |
 | **Image** | | | |
-| name | string | | The full name of the container image |
-| **Encrypted images** | | | |
-| keys | string[] | | Filepath to secret keys (GPG private key ring, JWE or PKCS7) and an optional password separated by colon |
-| recipients | string[] | | Protocol and certificate filepath separated by colon. Recipient certificate of the image, used only for PKCS7 and must be an x509 |
-| **Mount points** | | | |
-| destination | string | | Path where the file or directory is mounted in the container |
-| source | string | | Path to the file or directory on the host |
-| propagation_mode | string | | Allows mounting volumes in propagation mode on a container, the supported modes are: `rprivate`, `private`, `rshared`, `shared`, `rslave`, `slave` |
-| **Container config** | | | |
-| env | string[] | | Sets environment variables in the root container's process environment |
-| **Host config** | | | |
-| privileged | bool | false | Sets a container as privileged if the value is true |
-| network_mode | string | bridge | Configure the networking mode for the container, the possible options are `bridge` and `host` |
-| **Devices** | | | |
-| path_on_host | string | | Path on the host for mapped device |
-| path_in_container | string | | Path in the container for mapped device. |
-| cgroup_permissions | string | rwm | Sets cgroup permissions for the device access, possible options are: r (read), w (write), m (mknod) and all combinations of the three are possible |
-| **Restart policy** | | | |
-| type | string | unless-stopped | Strategy how to restart a container automatically, the supported types are: `always`, `no`, `on-failure` and `unless-stopped` |
-| maximum_retry_count | int | 1 | The number of retries that are made to restart the container on exit only if the policy is set to `on-failure` |
-| retry_timeout | int | 100 | The time out period in seconds for each retry that is made to restart the container on exit only if the policy is set to `on-failure` |
-| **Extra hosts** | | | |
-| extra_hosts | string[] | | Specify which hosts to be added in the current container's /etc/hosts file |
-| **Port mapping** | | | |
-| proto | string | tcp | The protocol for port mapping from the host to a container |
-| container_port | int | | Port of the mapped container |
-| host_ip | string | | IP of the mapped host |
-| host_port | int | | Beginning of the range of host port |
-| host_port_end | int | | End of the range of host port |
-| **Driver config** | | | |
-| type | string | json-file | The type of the full log driver configuration, the possible options are: `json-file` or `none` |
-| max_files | int | 2 | The maximum number of files the logs can be stored in. After the max number is reached, the files are rotated - the oldest is removed and the index is updated. This is applicable for json-file log driver only. |
-| max_size | string | 100M | The max size of the logs. This is applicable for json-file log driver only. |
-| root_dir | string | *Default container-management's meta path* | The target directory to store the logs per container. A sub-directory is created for each container’s ID. This is applicable for json-file log driver only. |
-| **Mode config** | | | |
-| mode | string | blocking | The supported logging modes are:<ul><li>blocking - instructs the logger not to use buffering</li><li>non-blocking - instructs the logger to use buffering</li></ul> |
-| max_buffer_size | string | 1M | Sets the max size of the logger buffer in the from 1, 1.2m. This option is applicable for non-blocking mode only. |
-| **Resources** | | | |
-| memory | string | | Hard memory limitation of a container, the minimum allowed value is 3M |
-| memory_reservation | string | | Soft memory limitation of a container. If `memory` is specified, the `memory_reservation` must be smaller than it |
-| memory_swap | string | | The total amount of memory and swap that the container can use |
+| name | string | | Fully qualified image reference, that follows the {{% refn "https://github.com/opencontainers/image-spec" %}}OCI Image Specification{{% /refn %}}, the format is: `host[:port]/[namespace/]name:tag` |
+| **Image - encryption** | | | |
+| keys | string[] | | Private keys (GPG private key ring, JWE or PKCS7) used for decrypting images, the format is: `filepath_private_key[:password]` |
+| recipients | string[] | | Recipients (only for PKCS7 and must be an x509) used for decrypting images, the format is: `pkcs7:filepath_x509_certificate` |
+| **Networking** | | | |
+| domain_name | string | <container_name>-domain | Domain name inside the container, if omitted the `container_name` with suffix -domain will be set |
+| host_name | string | <container_name>-host | Host name for the container, if omitted the `container_name` with suffix -host will be set |
+| network_mode | string | bridge | Container's networking capabilities type based on the desired communication mode, the possible options are: bridge, host or none |
+| extra_hosts | string[] | | Extra host name to IP address mapping added to the container network configuration, the format is: `hostname:ip` |
+| **Networking - port mappings** | | | |
+| proto | string | tcp | Protocol used for the port mapping from container to a host, the possible options are: tcp and udp |
+| container_port | int | | Port number on the container that is mapped to the host port |
+| host_ip | string | 0.0.0.0 | Host IP address |
+| host_port | int | | Host ports beginning range |
+| host_port_end | int | <host_port> | Host ports ending range |
+| **Host resources - devices** | | | |
+| path_on_host | string | | Path to the device on the host |
+| path_in_container | string | | Path to the device in the container |
+| cgroup_permissions | string | rwm | Cgroup permissions for the device access, possible options are: r(read), w(write), m(mknod) and all combinations are possible |
+| privileged | bool | false | Container access all devices on the host |
+| **Host resources - mount points** | | | |
+| source | string | | Path to the file or directory on the host that is referred from within the container |
+| destination | string | | Path to the file or directory is mounted inside the container |
+| propagation_mode | string | rprivate | Propagation mode in which mounts in container are accessible on host, the supported modes are: rprivate, private, rshared, shared, rslave or slave |
+| **Process** | | | |
+| env | string[] | | Environment variables that are set into container |
+| cmd | string[] | | Command with arguments that is executed upon container's start |
+| **Resource management** | | | |
+| memory | string | | Hard memory limitation of a container as a number with a unit suffix of B, K, M and G, the minimum allowed value is 3M |
+| memory_reservation | string | | Soft memory limitation of a container as a number with a unit suffix of B, K, M and G, if `memory` is specified, the `memory_reservation` must be smaller than it |
+| memory_swap | string | | Total amount of memory and swap that the container can use as a number with a unit suffix of B, K, M and G, use -1 to allow the container to use unlimited swap |
+| **Lifecycle** | | | |
+| type | string | unless-stopped | Container restart policy, the supported types are: always, no, on-failure and unless-stopped |
+| maximum_retry_count | int | 1 | Maximum number of retries that are made to restart the container on exit |
+| retry_timeout | int | 100 | Timeout period for each retry that is made to restart the container on exit |
+| **Logging** | | | |
+| type | string | json-file | Type in which the logs are produced, the possible options are: json-file or none |
+| max_files | int | 2 | Maximum log files before getting rotated |
+| max_size | string | 100M | Maximum logs size before getting rotated as a number with a unit suffix of B, K, M and G |
+| root_dir | string | <meta_path>/containers/<container_id> | Root directory where the log messages are stored per a container |
+| mode | string | blocking | Messaging delivery mode from the container to log driver, the supported modes are: blocking and non-blocking |
+| max_buffer_size | string | 1M | Maximum buffer size to store the messages per container as a number with a unit suffix of B, K, M and G |
 
-#### Example
-The minimal required information for the container instance is the receptive container image.
+### Example
+
+The minimal required information to create the container instance is the receptive container image.
 
 ```json
 {
   "image": {
-    "name": "docker.io/nginxdemos/hello:plain-text"
+    "name": "docker.io/library/influxdb:1.8.4"
   }
 }
 ```
@@ -73,79 +73,75 @@ The minimal required information for the container instance is the receptive con
 
 The configuration can be further adjusted according to the use case. The following template illustrates all possible properties with their default values.
 
+{{% warn %}}
+Be aware that some combinations require property removal.
+{{% /warn %}}
+
 ```json
 {
-   "container_name":"test-name",
-   "image":{
-      "name":"docker.io/nginxdemos/hello:plain-text",
-      "decrypt_config":{
-         "keys":[
-            "/home/user/pkcs7/key.pem"
-         ],
-         "recipients":[
-            "pkcs7:/home/user/pkcs7/cert.pem"
-         ]
-      }
-   },
-   "domain_name":"test-name-domain",
-   "host_name":"test-name-host",
-   "mount_points":[
-      {
-         "destination":"/etc/test-config",
-         "source":"/etc/test-source-config",
-         "propagation_mode":"rprivate"
-      }
-   ],
-   "config":{
-      "env":[
-         "VAR_1=1",
-         "VAR_2=my var"
-      ]
-   },
-   "host_config":{
-      "devices":[
-         {
-            "path_on_host":"/dev/ttyACM0",
-            "path_in_container":"/dev/ttyACM1",
-            "cgroup_permissions":"rwm"
-         }
-      ],
-      "privileged":false,
-      "network_mode":"bridge",
-      "restart_policy":{
-         "maximum_retry_count":0,
-         "retry_timeout":0,
-         "type":"unless-stopped"
-      },
-      "extra_hosts":[
-         "ctrhost:host_ip"
-      ],
-      "port_mappings":[
-         {
-            "proto":"tcp",
-            "container_port":80,
-            "host_ip":"192.168.1.101",
-            "host_port":81,
-            "host_port_end":82
-         }
-      ],
-      "log_config":{
-         "driver_config":{
-            "type":"json-file",
-            "max_files":2,
-            "max_size":"100M",
-            "root_dir":"/my/secured/dir"
-         },
-         "mode_config":{
-            "mode":"non-blocking",
-            "max_buffer_size":"5M"
-         }
-      },
-      "resources":{
-         "memory":"200M",
-         "memory_reservation":"100M",
-         "memory_swap":"500M"
-      }
-   }
+    "container_name": "",
+    "image": {
+        "name": "",
+        "decrypt_config": {
+            "keys": [],
+            "recipients": []
+        }
+    },
+    "domain_name": "",
+    "host_name": "",
+    "mount_points": [
+        {
+            "destination": "",
+            "source": "",
+            "propagation_mode": "rprivate"
+        }
+    ],
+    "config": {
+        "env": [],
+        "cmd": []
+    },
+    "host_config": {
+        "devices": [
+            {
+                "path_on_host": "",
+                "path_in_container": "",
+                "cgroup_permissions": "rwm"
+            }
+        ],
+        "network_mode": "bridge",
+        "privileged": false,
+        "extra_hosts": [],
+        "port_mappings": [
+            {
+                "proto": "tcp",
+                "container_port": 0,
+                "host_ip": "0.0.0.0",
+                "host_port": 0,
+                "host_port_end": 0
+            }
+        ],
+        "resources": {
+            "memory": "",
+            "memory_reservation": "",
+            "memory_swap": ""
+        },
+        "restart_policy": {
+            "type": "unless-stopped",
+            "maximum_retry_count": 1,
+            "retry_timeout": 100
+        },
+        "log_config": {
+            "driver_config": {
+                "type": "json-file",
+                "max_files": 2,
+                "max_size": "100M",
+                "root_dir": ""
+            },
+            "mode_config": {
+                "mode": "blocking",
+                "max_buffer_size": "1M"
+            }
+        }
+    }
 }
 ```

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -47,8 +47,8 @@ To control all aspects of the container instance behavior.
 | memory_swap | string | | Total amount of memory and swap that the container can use as a number with a unit suffix of B, K, M and G, use -1 to allow the container to use unlimited swap |
 | **Lifecycle** | | | |
 | type | string | unless-stopped | Container restart policy, the supported types are: always, no, on-failure and unless-stopped |
-| maximum_retry_count | int | 1 | Maximum number of retries that are made to restart the container on exit |
-| retry_timeout | int | 100 | Timeout period for each retry that is made to restart the container on exit |
+| maximum_retry_count | int | | Maximum number of retries that are made to restart the container on exit |
+| retry_timeout | int | | Timeout period in seconds for each retry that is made to restart the container on exit |
 | **Logging** | | | |
 | type | string | json-file | Type in which the logs are produced, the possible options are: json-file or none |
 | max_files | int | 2 | Maximum log files before getting rotated |
@@ -127,8 +127,8 @@ Be aware that some combinations require property removal.
         },
         "restart_policy": {
             "type": "unless-stopped",
-            "maximum_retry_count": 1,
-            "retry_timeout": 100
+            "maximum_retry_count": 0,
+            "retry_timeout": 0
         },
         "log_config": {
             "driver_config": {

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -15,7 +15,7 @@ To control all aspects of the container instance behavior.
 | container_name | string | <container_id> | User-defined name for the container, if omitted the internally auto-generated container ID will be set |
 | **Image** | | | |
 | name | string | | Fully qualified image reference, that follows the {{% refn "https://github.com/opencontainers/image-spec" %}}OCI Image Specification{{% /refn %}}, the format is: `host[:port]/[namespace/]name:tag` |
-| **Image - encryption** | | | |
+| **Image - decryption** | | | |
 | keys | string[] | | Private keys (GPG private key ring, JWE or PKCS7) used for decrypting images, the format is: `filepath_private_key[:password]` |
 | recipients | string[] | | Recipients (only for PKCS7 and must be an x509) used for decrypting images, the format is: `pkcs7:filepath_x509_certificate` |
 | **Networking** | | | |
@@ -27,8 +27,8 @@ To control all aspects of the container instance behavior.
 | proto | string | tcp | Protocol used for the port mapping from container to a host, the possible options are: tcp and udp |
 | container_port | int | | Port number on the container that is mapped to the host port |
 | host_ip | string | 0.0.0.0 | Host IP address |
-| host_port | int | | Host ports beginning range |
-| host_port_end | int | <host_port> | Host ports ending range |
+| host_port | int | | Beginning of the host ports range |
+| host_port_end | int | <host_port> | Ending of the host ports range |
 | **Host resources - devices** | | | |
 | path_on_host | string | | Path to the device on the host |
 | path_in_container | string | | Path to the device in the container |
@@ -36,7 +36,7 @@ To control all aspects of the container instance behavior.
 | privileged | bool | false | Container access all devices on the host |
 | **Host resources - mount points** | | | |
 | source | string | | Path to the file or directory on the host that is referred from within the container |
-| destination | string | | Path to the file or directory is mounted inside the container |
+| destination | string | | Path to the file or directory that is mounted inside the container |
 | propagation_mode | string | rprivate | Propagation mode in which mounts in container are accessible on host, the supported modes are: rprivate, private, rshared, shared, rslave or slave |
 | **Process** | | | |
 | env | string[] | | Environment variables that are set into container |
@@ -52,7 +52,7 @@ To control all aspects of the container instance behavior.
 | **Logging** | | | |
 | type | string | json-file | Type in which the logs are produced, the possible options are: json-file or none |
 | max_files | int | 2 | Maximum log files before getting rotated |
-| max_size | string | 100M | Maximum logs size before getting rotated as a number with a unit suffix of B, K, M and G |
+| max_size | string | 100M | Maximum log file size before getting rotated as a number with a unit suffix of B, K, M and G |
 | root_dir | string | <meta_path>/containers/<container_id> | Root directory where the log messages are stored per a container |
 | mode | string | blocking | Messaging delivery mode from the container to log driver, the supported modes are: blocking and non-blocking |
 | max_buffer_size | string | 1M | Maximum buffer size to store the messages per container as a number with a unit suffix of B, K, M and G |

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -1,0 +1,151 @@
+---
+title: "Container configuration"
+type: docs
+description: >
+  Customize the deployment of container instance.
+weight: 2
+---
+
+### Properties
+
+To control all aspects of the container instance behavior.
+
+| Property | Type | Default | Description |
+| - | - | - | - |
+| container_name | string | \<container ID\> | User-defined name of the container |
+| domain_name | string | \<container name\>-domain | Domain name inside the container |
+| host_name | string | \<container name\>-host | Host name for the container  |
+| **Image** | | | |
+| name | string | | The full name of the container image |
+| **Encrypted images** | | | |
+| keys | string[] | | Filepath to secret keys (GPG private key ring, JWE or PKCS7) and an optional password separated by colon |
+| recipients | string[] | | Protocol and certificate filepath separated by colon. Recipient certificate of the image, used only for PKCS7 and must be an x509 |
+| **Mount points** | | | |
+| destination | string | | Path where the file or directory is mounted in the container |
+| source | string | | Path to the file or directory on the host |
+| propagation_mode | string | | Allows mounting volumes in propagation mode on a container, the supported modes are: `rprivate`, `private`, `rshared`, `shared`, `rslave`, `slave` |
+| **Container config** | | | |
+| env | string[] | | Sets environment variables in the root container's process environment |
+| **Host config** | | | |
+| privileged | bool | false | Sets a container as privileged if the value is true |
+| network_mode | string | bridge | Configure the networking mode for the container, the possible options are `bridge` and `host` |
+| **Devices** | | | |
+| path_on_host | string | | Path on the host for mapped device |
+| path_in_container | string | | Path in the container for mapped device. |
+| cgroup_permissions | string | rwm | Sets cgroup permissions for the device access, possible options are: r (read), w (write), m (mknod) and all combinations of the three are possible |
+| **Restart policy** | | | |
+| type | string | unless-stopped | Strategy how to restart a container automatically, the supported types are: `always`, `no`, `on-failure` and `unless-stopped` |
+| maximum_retry_count | int | 1 | The number of retries that are made to restart the container on exit only if the policy is set to `on-failure` |
+| retry_timeout | int | 100 | The time out period in seconds for each retry that is made to restart the container on exit only if the policy is set to `on-failure` |
+| **Extra hosts** | | | |
+| extra_hosts | string[] | | Specify which hosts to be added in the current container's /etc/hosts file |
+| **Port mapping** | | | |
+| proto | string | tcp | The protocol for port mapping from the host to a container |
+| container_port | int | | Port of the mapped container |
+| host_ip | string | | IP of the mapped host |
+| host_port | int | | Beginning of the range of host port |
+| host_port_end | int | | End of the range of host port |
+| **Driver config** | | | |
+| type | string | json-file | The type of the full log driver configuration, the possible options are: `json-file` or `none` |
+| max_files | int | 2 | The maximum number of files the logs can be stored in. After the max number is reached, the files are rotated - the oldest is removed and the index is updated. This is applicable for json-file log driver only. |
+| max_size | string | 100M | The max size of the logs. This is applicable for json-file log driver only. |
+| root_dir | string | *Default container-management's meta path* | The target directory to store the logs per container. A sub-directory is created for each container’s ID. This is applicable for json-file log driver only. |
+| **Mode config** | | | |
+| mode | string | blocking | The supported logging modes are:<ul><li>blocking - instructs the logger not to use buffering</li><li>non-blocking - instructs the logger to use buffering</li></ul> |
+| max_buffer_size | string | 1M | Sets the max size of the logger buffer in the from 1, 1.2m. This option is applicable for non-blocking mode only. |
+| **Resources** | | | |
+| memory | string | | Hard memory limitation of a container, the minimum allowed value is 3M |
+| memory_reservation | string | | Soft memory limitation of a container. If `memory` is specified, the `memory_reservation` must be smaller than it |
+| memory_swap | string | | The total amount of memory and swap that the container can use |
+
+#### Example
+The minimal required information for the container instance is the receptive container image.
+
+```json
+{
+  "image": {
+    "name": "docker.io/nginxdemos/hello:plain-text"
+  }
+}
+```
+
+### Template
+
+The configuration can be further adjusted according to the use case. The following template illustrates all possible properties with their default values.
+
+```json
+{
+   "container_name":"test-name",
+   "image":{
+      "name":"docker.io/nginxdemos/hello:plain-text",
+      "decrypt_config":{
+         "keys":[
+            "/home/user/pkcs7/key.pem"
+         ],
+         "recipients":[
+            "pkcs7:/home/user/pkcs7/cert.pem"
+         ]
+      }
+   },
+   "domain_name":"test-name-domain",
+   "host_name":"test-name-host",
+   "mount_points":[
+      {
+         "destination":"/etc/test-config",
+         "source":"/etc/test-source-config",
+         "propagation_mode":"rprivate"
+      }
+   ],
+   "config":{
+      "env":[
+         "VAR_1=1",
+         "VAR_2=my var"
+      ]
+   },
+   "host_config":{
+      "devices":[
+         {
+            "path_on_host":"/dev/ttyACM0",
+            "path_in_container":"/dev/ttyACM1",
+            "cgroup_permissions":"rwm"
+         }
+      ],
+      "privileged":false,
+      "network_mode":"bridge",
+      "restart_policy":{
+         "maximum_retry_count":0,
+         "retry_timeout":0,
+         "type":"unless-stopped"
+      },
+      "extra_hosts":[
+         "ctrhost:host_ip"
+      ],
+      "port_mappings":[
+         {
+            "proto":"tcp",
+            "container_port":80,
+            "host_ip":"192.168.1.101",
+            "host_port":81,
+            "host_port_end":82
+         }
+      ],
+      "log_config":{
+         "driver_config":{
+            "type":"json-file",
+            "max_files":2,
+            "max_size":"100M",
+            "root_dir":"/my/secured/dir"
+         },
+         "mode_config":{
+            "mode":"non-blocking",
+            "max_buffer_size":"5M"
+         }
+      },
+      "resources":{
+         "memory":"200M",
+         "memory_reservation":"100M",
+         "memory_swap":"500M"
+      }
+   }
+}
+```

--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -16,15 +16,15 @@ To control all aspects of the container instance behavior.
 | **Image** | | | |
 | name | string | | Fully qualified image reference, that follows the {{% refn "https://github.com/opencontainers/image-spec" %}}OCI Image Specification{{% /refn %}}, the format is: `host[:port]/[namespace/]name:tag` |
 | **Image - decryption** | | | |
-| keys | string[] | | Private keys (GPG private key ring, JWE or PKCS7) used for decrypting images, the format is: `filepath_private_key[:password]` |
-| recipients | string[] | | Recipients (only for PKCS7 and must be an x509) used for decrypting images, the format is: `pkcs7:filepath_x509_certificate` |
+| keys | string[] | | Private keys (GPG private key ring, JWE or PKCS7) used for decrypting the container's image, the format is: `filepath_private_key[:password]` |
+| recipients | string[] | | Recipients (only for PKCS7 and must be an x509) used for decrypting the container's image, the format is: `pkcs7:filepath_x509_certificate` |
 | **Networking** | | | |
 | domain_name | string | <container_name>-domain | Domain name inside the container, if omitted the `container_name` with suffix -domain will be set |
 | host_name | string | <container_name>-host | Host name for the container, if omitted the `container_name` with suffix -host will be set |
-| network_mode | string | bridge | Container's networking capabilities type based on the desired communication mode, the possible options are: bridge, host or none |
-| extra_hosts | string[] | | Extra host name to IP address mapping added to the container network configuration, the format is: `hostname:ip` |
+| network_mode | string | bridge | The container's networking capabilities type based on the desired communication mode, the possible options are: bridge, host or none |
+| extra_hosts | string[] | | Extra host name to IP address mappings added to the container network configuration, the format is: `hostname:ip` |
 | **Networking - port mappings** | | | |
-| proto | string | tcp | Protocol used for the port mapping from container to a host, the possible options are: tcp and udp |
+| proto | string | tcp | Protocol used for the port mapping from the container to the host, the possible options are: tcp and udp |
 | container_port | int | | Port number on the container that is mapped to the host port |
 | host_ip | string | 0.0.0.0 | Host IP address |
 | host_port | int | | Beginning of the host ports range |
@@ -33,29 +33,29 @@ To control all aspects of the container instance behavior.
 | path_on_host | string | | Path to the device on the host |
 | path_in_container | string | | Path to the device in the container |
 | cgroup_permissions | string | rwm | Cgroup permissions for the device access, possible options are: r(read), w(write), m(mknod) and all combinations are possible |
-| privileged | bool | false | Container access all devices on the host |
+| privileged | bool | false | Grant root capabilities to all devices on the host system |
 | **Host resources - mount points** | | | |
 | source | string | | Path to the file or directory on the host that is referred from within the container |
 | destination | string | | Path to the file or directory that is mounted inside the container |
 | propagation_mode | string | rprivate | Bind propagation for the mount, supported are: rprivate, private, rshared, shared, rslave or slave |
 | **Process** | | | |
-| env | string[] | | Environment variables that are set into container |
-| cmd | string[] | | Command with arguments that is executed upon container's start |
+| env | string[] | | Environment variables that are set into the container |
+| cmd | string[] | | Command with arguments that is executed upon the container's start |
 | **Resource management** | | | |
-| memory | string | | Hard memory limitation of a container as a number with a unit suffix of B, K, M and G, the minimum allowed value is 3M |
-| memory_reservation | string | | Soft memory limitation of a container as a number with a unit suffix of B, K, M and G, if `memory` is specified, the `memory_reservation` must be smaller than it |
+| memory | string | | Hard memory limitation of the container as a number with a unit suffix of B, K, M and G, the minimum allowed value is 3M |
+| memory_reservation | string | | Soft memory limitation of the container as a number with a unit suffix of B, K, M and G, if `memory` is specified, the `memory_reservation` must be smaller than it |
 | memory_swap | string | | Total amount of memory and swap that the container can use as a number with a unit suffix of B, K, M and G, use -1 to allow the container to use unlimited swap |
 | **Lifecycle** | | | |
-| type | string | unless-stopped | Container restart policy, the supported types are: always, no, on-failure and unless-stopped |
+| type | string | unless-stopped | The container restart policy, the supported types are: always, no, on-failure and unless-stopped |
 | maximum_retry_count | int | | Maximum number of retries that are made to restart the container on exit with fail, if the `type` is on-failure |
 | retry_timeout | int | | Timeout period in seconds for each retry that is made to restart the container on exit with fail, if the `type` is on-failure |
 | **Logging** | | | |
 | type | string | json-file | Type in which the logs are produced, the possible options are: json-file or none |
 | max_files | int | 2 | Maximum log files before getting rotated |
 | max_size | string | 100M | Maximum log file size before getting rotated as a number with a unit suffix of B, K, M and G |
-| root_dir | string | <meta_path>/containers/<container_id> | Root directory where the log messages are stored per a container |
+| root_dir | string | <meta_path>/containers/<container_id> | Root directory where the log messages are stored per the container |
 | mode | string | blocking | Messaging delivery mode from the container to the log driver, the supported modes are: blocking and non-blocking |
-| max_buffer_size | string | 1M | Maximum buffer size to store the messages per container as a number with a unit suffix of B, K, M and G |
+| max_buffer_size | string | 1M | Maximum buffer size to store the messages for the container as a number with a unit suffix of B, K, M and G |
 
 ### Example
 


### PR DESCRIPTION
[#40] Provide Reference guide for the container instance

- provide the information relevant to available configuration per container instance
- add an example how to use this configuration
- add a reference guide for container instance configuration in Eclipse Kanto Documentation

Signed-off-by: Trifonova Antonia <Antonia.Trifonova@bosch.io>