### PR TITLE
Ensured AMQP connectivity for the Hono sandbox tenants

### DIFF
--- a/quickstart/hono_provisioning.sh
+++ b/quickstart/hono_provisioning.sh
@@ -23,7 +23,7 @@ export AUTH_ID=
 # A password for the device to authenticate with
 export PWD=
 
-curl -i -X POST http://$HONO_EP:28080/v1/tenants/$TENANT
+curl -i -X POST http://$HONO_EP:28080/v1/tenants/$TENANT -H  "content-type: application/json"  --data-binary '{"ext": {"messaging-type": "amqp"}}'
 curl -i -X POST http://$HONO_EP:28080/v1/devices/$TENANT/$DEVICE_ID -H  "content-type: application/json" --data-binary '{"authorities":["auto-provisioning-enabled"]}'
 curl -i -X PUT -H "content-type: application/json" --data-binary '[{
   "type": "hashed-password",


### PR DESCRIPTION
[#63]  Added an explicit messaging configuration set to AMQP for the provisioned Hono tenants
that are to be used by the quickstart and how-to Kanto Python scripts.

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>