### PR TITLE
Revert Hugo version

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.101.0'
+          hugo-version: '0.100.2'
           extended: true
 
       - name: Setup Node


### PR DESCRIPTION
[#72] Revert Hugo version

Reverted Hugo version from 0.101.0 to 0.100.2 in "documentation.yaml"

Signed-off-by: Daniel Milchev <fixed-term.daniel.milchev@bosch.io>