### PR TITLE
Document the TLS configuration for secure uploads

### DIFF
--- a/web/site/content/docs/references/file-upload-config.md
+++ b/web/site/content/docs/references/file-upload-config.md
@@ -29,9 +29,10 @@ To control all aspects of the file upload behavior.
 | broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the file upload will connect for the local communication, the format is: `scheme://host:port` |
 | username | string | | Username that is a part of the credentials |
 | password | string | | Password that is a part of the credentials |
+| **Local connectivity - TLS** | | | |
 | caCert | string | | PEM encoded CA certificates file |
-| cert | string | | PEM encoded certificate file to authenticate to the MQTT endpoint |
-| key | string | | PEM encoded unencrypted private key file to authenticate to the MQTT endpoint |
+| cert | string | | PEM encoded certificate file to authenticate to the MQTT server/broker |
+| key | string | | PEM encoded unencrypted private key file to authenticate to the MQTT server/broker |
 | **Logging** | | | |
 | logFile | string | log/file-upload.log | Path to the file where log messages are written |
 | logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
@@ -73,6 +74,9 @@ The following template illustrates all possible properties with their default va
     "broker": "tcp://localhost:1883",
     "username": "",
     "password": "",
+    "caCert": "",
+    "cert": "",
+    "key": "",
     "logFile": "log/file-upload.log",
     "logLevel": "INFO",
     "logFileCount": 5,

--- a/web/site/content/docs/references/file-upload-config.md
+++ b/web/site/content/docs/references/file-upload-config.md
@@ -29,6 +29,9 @@ To control all aspects of the file upload behavior.
 | broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the file upload will connect for the local communication, the format is: `scheme://host:port` |
 | username | string | | Username that is a part of the credentials |
 | password | string | | Password that is a part of the credentials |
+| caCert | string | | A PEM encoded CA certificates `file` for MQTT broker connection |
+| cert | string | | A PEM encoded certificate `file` for MQTT broker connection |
+| key | string | | A PEM encoded unencrypted private key `file` for MQTT broker connection |
 | **Logging** | | | |
 | logFile | string | log/file-upload.log | Path to the file where log messages are written |
 | logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |

--- a/web/site/content/docs/references/file-upload-config.md
+++ b/web/site/content/docs/references/file-upload-config.md
@@ -29,9 +29,9 @@ To control all aspects of the file upload behavior.
 | broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the file upload will connect for the local communication, the format is: `scheme://host:port` |
 | username | string | | Username that is a part of the credentials |
 | password | string | | Password that is a part of the credentials |
-| caCert | string | | A PEM encoded CA certificates `file` for MQTT broker connection |
-| cert | string | | A PEM encoded certificate `file` for MQTT broker connection |
-| key | string | | A PEM encoded unencrypted private key `file` for MQTT broker connection |
+| caCert | string | | PEM encoded CA certificates file |
+| cert | string | | PEM encoded certificate file to authenticate to the MQTT endpoint |
+| key | string | | PEM encoded unencrypted private key file to authenticate to the MQTT endpoint |
 | **Logging** | | | |
 | logFile | string | log/file-upload.log | Path to the file where log messages are written |
 | logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |


### PR DESCRIPTION
[#75] Document the TLS configuration for secure uploads

- **caCert**, **cert** and **key** flags added info

Signed-off-by: Georgi Boyvalenkov <Georgi.Boyvalenkov@bosch.io>