### PR TITLE
Provide Reference guide for the Kanto Container Management

### DIFF
--- a/web/site/content/docs/references/containers/container-config.md
+++ b/web/site/content/docs/references/containers/container-config.md
@@ -21,7 +21,7 @@ To control all aspects of the container instance behavior.
 | **Networking** | | | |
 | domain_name | string | <container_name>-domain | Domain name inside the container, if omitted the `container_name` with suffix -domain will be set |
 | host_name | string | <container_name>-host | Host name for the container, if omitted the `container_name` with suffix -host will be set |
-| network_mode | string | bridge | The container's networking capabilities type based on the desired communication mode, the possible options are: bridge, host or none |
+| network_mode | string | bridge | The container's networking capabilities type based on the desired communication mode, the possible options are: bridge or host |
 | extra_hosts | string[] | | Extra host name to IP address mappings added to the container network configuration, the format is: `hostname:ip` |
 | **Networking - port mappings** | | | |
 | proto | string | tcp | Protocol used for the port mapping from the container to the host, the possible options are: tcp and udp |

--- a/web/site/content/docs/references/containers/container-manager-config.md
+++ b/web/site/content/docs/references/containers/container-manager-config.md
@@ -37,7 +37,6 @@ To control all aspects of the container manager behavior.
 | home_dir | string | /var/lib/container-management | Home directory for the network manager data |
 | exec_root_dir | string | /var/run/container-management | Root directory for the network manager's executable artifacts |
 | **Networking - bridge** | | | |
-| disable | bool | false | Forbid the bridge networking |
 | name | string | kanto-cm0 | Bridge name |
 | ip4 | string | | Bridge IPv4 address |
 | fcidr4 | string | | IPv4 address range for the bridge, using the standard CIDR notation |
@@ -136,7 +135,6 @@ Be aware that in the registry configuration the host (used as a key) has to be s
         "home_dir": "/var/lib/container-management",
         "exec_root_dir": "/var/run/container-management",
         "default_bridge": {
-            "disable": false,
             "name": "kanto-cm0",
             "ip4": "",
             "fcidr4": "",

--- a/web/site/content/docs/references/containers/container-manager-config.md
+++ b/web/site/content/docs/references/containers/container-manager-config.md
@@ -1,0 +1,184 @@
+---
+title: "Manager configuration"
+type: docs
+description: >
+  Customize the container manager components.
+weight: 2
+---
+
+### Properties
+
+To control all aspects of the container manager behavior.
+
+| Property | Type | Default | Description |
+| - | - | - | - |
+| home_dir | string | /var/lib/container-management | Home directory for the container manager data |
+| exec_root_dir | string | /var/run/container-management | Root directory for the container manager's executable artifacts |
+| container_client_sid | string | container-management.service.local.v1.service-containerd-client | Unique identifier that is used for an interaction with the runtime |
+| network_manager_sid | string | container-management.service.local.v1.service-libnetwork-manager | Unique identifier that is used for networking |
+| default_ctrs_stop_timeout | int | 30 | Timeout in seconds for a container to stop gracefully, otherwise its root process will be force stopped |
+| **Runtime** | | | |
+| default_ns | string | kanto-cm | Namespace that is used by the runtime for isolation |
+| address_path | string | /run/containerd/containerd.sock | Path to the runtime's communication endpoint |
+| home_dir | string | /var/lib/container-management | Home directory for the runtime data |
+| exec_root_dir | string | /var/run/container-management | Root directory for the runtime's executable artifacts |
+| image_dec_keys | string[] | | Private keys (GPG private key ring, JWE or PKCS7) used for decrypting container images, the format is: `filepath_private_key[:password]` |
+| image_dec_recipients | string[] | | Recipients (only for PKCS7 and must be an x509) used for decrypting container images, the format is: `pkcs7:filepath_x509_certificate` |
+| runc_runtime | string | io.containerd.runc.v2 | Runc communication mode, the possible values are: io.containerd.runtime.v1.linux, io.containerd.runc.v1 and io.containerd.runc.v2 |
+| **Registry access - secure** | | | |
+| user_id | string | | User unique identifier to authenticate to the image registry |
+| password | string | | Password to authenticate to the image registry |
+| root_ca | string | | PEM encoded CA certificates file |
+| client_cert | string | | PEM encoded certificate file to authenticate to the image registry |
+| client_key | string | | PEM encoded unencrypted private key file to authenticate to the image registry |
+| **Registry access - insecure** | | | |
+| insecure_registries | string[] | localhost | Image registries that do not use valid certificates or do not require a HTTPS connection, the format is: `host[:port]` |
+| **Networking** | | | |
+| home_dir | string | /var/lib/container-management | Home directory for the network manager data |
+| exec_root_dir | string | /var/run/container-management | Root directory for the network manager's executable artifacts |
+| **Networking - bridge** | | | |
+| disable | bool | false | Forbid the bridge networking |
+| name | string | kanto-cm0 | Bridge name |
+| ip4 | string | | Bridge IPv4 address |
+| fcidr4 | string | | IPv4 address range for the bridge, using the standard CIDR notation |
+| gwip4 | string | | Bridge gateway IPv4 address |
+| enable_ip6 | bool | false | Permit the bridge IPv6 support |
+| mtu | int | 1500 | Bridge maximum transmission unit in bytes |
+| icc | bool | true | Permit the inter-container communication |
+| ip_tables | bool | true | Permit the IP tables rules |
+| ip_forward | bool | true | Permit the IP forwarding |
+| ip_masq | bool | true | Permit the IP masquerading |
+| userland_proxy | bool | false | Forbid the userland proxy for the loopback traffic |
+| **Local communication** | | | |
+| protocol | string | unix | Communication protocol used for accessing the gRPC server, the possible values are: tcp, tcp4, tcp6, unix or unixpacket |
+| address_path | string | /run/container-management/container-management.sock | Path to the gRPC server's communication endpoint |
+| **Digital twin** | | | |
+| enable | bool | true | Permit the container manager digital twin representation |
+| home_dir | string | /var/lib/container-management | Home directory for the digital twin data |
+| features | string[] | ContainerFactory, SoftwareUpdatable | Features that will be registered for the container manager digital twin, the possible values are: ContainerFactory, SoftwareUpdatable |
+| **Digital twin - connectivity** | | | |
+| broker_url | string | tcp://localhost:1883 | Address of the MQTT server/broker that the container manager will connect for the local communication, the format is: `scheme://host:port` |
+| keep_alive | int | 20000 | Keep alive duration in milliseconds for the MQTT requests |
+| disconnect_timeout | int | 250 | Disconnect timeout in milliseconds for the MQTT server/broker |
+| client_username | string | | Username that is a part of the credentials |
+| client_password | string | | Password that is a part of the credentials |
+| connect_timeout | int | 30000 | Connect timeout in milliseconds for the MQTT server/broker |
+| acknowledge_timeout | int | 15000 | Acknowledge timeout in milliseconds for the MQTT requests |
+| subscribe_timeout | int | 15000 | Subscribe timeout in milliseconds for the MQTT requests |
+| unsubscribe_timeout | int | 5000 | Unsubscribe timeout in milliseconds for the MQTT requests |
+| **Logging** | | | |
+| log_file | string | log/container-management.log | Path to the file where the container manager's log messages are written |
+| log_level | string | INFO | All log messages at this or a higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
+| log_file_count | int | 5 | Log file maximum rotations count |
+| log_file_max_age | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files |
+| log_file_size | int | 2 | Log file size in MB before it gets rotated |
+| syslog | bool | false | Route logs to the local syslog |
+
+### Example
+
+The minimal required configuration that sets a timeout period of 5 seconds for the managed containers to stop gracefully.
+
+```json
+{
+    "manager": {
+        "default_ctrs_stop_timeout": 5
+    },
+    "log": {
+        "log_file": "/var/log/container-management/container-management.log"
+    }
+}
+```
+
+### Template
+
+The configuration can be further adjusted according to the use case.
+The following template illustrates all possible properties with their default values.
+
+{{% warn %}}
+Be aware that in the registry configuration the host (used as a key) has to be set instead of the default empty string, the format is: host[:port]
+{{% /warn %}}
+
+```json
+{
+    "manager": {
+        "home_dir": "/var/lib/container-management",
+        "exec_root_dir": "/var/run/container-management",
+        "container_client_sid": "container-management.service.local.v1.service-containerd-client",
+        "network_manager_sid": "container-management.service.local.v1.service-libnetwork-manager",
+        "default_ctrs_stop_timeout": 30
+    },
+    "containers": {
+        "default_ns": "kanto-cm",
+        "address_path": "/run/containerd/containerd.sock",
+        "exec_root_dir": "/var/run/container-management",
+        "home_dir": "/var/lib/container-management",
+        "image_dec_keys": [],
+        "image_dec_recipients": [],
+        "runc_runtime": "io.containerd.runc.v2",
+        "registry_configurations": {
+            "": {
+                "credentials": {
+                    "user_id": "",
+                    "password": ""
+                },
+                "transport": {
+                    "root_ca": "",
+                    "client_cert": "",
+                    "client_key": ""
+                }
+            }
+        },
+        "insecure_registries": [
+            "localhost"
+        ]
+    },
+    "network": {
+        "home_dir": "/var/lib/container-management",
+        "exec_root_dir": "/var/run/container-management",
+        "default_bridge": {
+            "disable": false,
+            "name": "kanto-cm0",
+            "ip4": "",
+            "fcidr4": "",
+            "enable_ip6": false,
+            "mtu": 1500,
+            "icc": true,
+            "ip_tables": true,
+            "ip_forward": true,
+            "ip_masq": true,
+            "userland_proxy": false
+        }
+    },
+    "grpc_server": {
+        "protocol": "unix",
+        "address_path": "/run/container-management/container-management.sock"
+    },
+    "things": {
+        "enable": true,
+        "home_dir": "/var/lib/container-management",
+        "features": [
+            "ContainerFactory",
+            "SoftwareUpdatable"
+        ],
+        "connection": {
+            "broker_url": "tcp://localhost:1883",
+            "keep_alive": 20000,
+            "disconnect_timeout": 250,
+            "client_username": "",
+            "client_password": "",
+            "connect_timeout": 30000,
+            "acknowledge_timeout": 15000,
+            "subscribe_timeout": 15000,
+            "unsubscribe_timeout": 5000
+        }
+    },
+    "log": {
+        "log_file": "log/container-management.log",
+        "log_level": "INFO",
+        "log_file_count": 5,
+        "log_file_size": 2,
+        "log_file_max_age": 28,
+        "syslog": false
+    }
+}
+```

--- a/web/site/content/docs/references/containers/container-manager-config.md
+++ b/web/site/content/docs/references/containers/container-manager-config.md
@@ -54,7 +54,7 @@ To control all aspects of the container manager behavior.
 | **Digital twin** | | | |
 | enable | bool | true | Permit the container manager digital twin representation |
 | home_dir | string | /var/lib/container-management | Home directory for the digital twin data |
-| features | string[] | ContainerFactory, SoftwareUpdatable | Features that will be registered for the container manager digital twin, the possible values are: ContainerFactory, SoftwareUpdatable |
+| features | string[] | ContainerFactory, SoftwareUpdatable | Features that will be registered for the container manager digital twin, the possible values are: ContainerFactory and SoftwareUpdatable |
 | **Digital twin - connectivity** | | | |
 | broker_url | string | tcp://localhost:1883 | Address of the MQTT server/broker that the container manager will connect for the local communication, the format is: `scheme://host:port` |
 | keep_alive | int | 20000 | Keep alive duration in milliseconds for the MQTT requests |


### PR DESCRIPTION
[#71] Provide Reference guide for the Kanto Container Management

- Provide the reference guide for the container manager configuration
- Add an example of how to use this configuration
- Add a template with all possible configuration properties and their default values
- Fix the description of the network mode property

Signed-off-by: Trifonova Antonia <Antonia.Trifonova@bosch.io>