### PR TITLE
Fix website UI formatting for small, medium and extra large devices

### DIFF
--- a/web/site/assets/scss/_screen.scss
+++ b/web/site/assets/scss/_screen.scss
@@ -3,10 +3,11 @@
   .w-lg-75 {
     width: 75% !important;
   }
-  // Sets the content width in blog and docs
-  .td-max-width-on-larger-screens {
-    max-width: 100% !important;
-  }
+}
+
+// Sets the content width in blog and docs
+.td-max-width-on-larger-screens {
+  max-width: 100% !important;
 }
 
 // Overwriting height and padding used for cover blocks


### PR DESCRIPTION
[#105] Fix website UI formatting for small, medium and extra large devices

Temporarily changed ".td-max-width-on-larger-screens" until the project is migrated to a new docsy version.

Signed-off-by: Daniel Milchev <fixed-term.daniel.milchev@bosch.io>