### PR TITLE
File backup reference guide

### DIFF
--- a/web/site/content/docs/references/file-backup-config.md
+++ b/web/site/content/docs/references/file-backup-config.md
@@ -2,7 +2,7 @@
 title: "File backup configuration"
 type: docs
 description: >
-  Customize the file backup and recovery to and from a backend storage.
+  Customize the files backup and restore to and from a backend storage.
 weight: 6
 ---
 
@@ -13,17 +13,19 @@ To control all aspects of the file backup behavior.
 | Property | Type | Default | Description |
 | - | - | - | - |
 | featureId | string | BackupAndRestore | Feature unique identifier in the scope of the edge digital twin |
+| type | string | file | Type of the files that are backed up by this feature |
+| context | string | edge | Context of the files backed up by this feature, unique in the scope of the `type` |
 | dir | string | | Directory to be backed up |
-| storage | string | ./storage | Directory where backups and downloads will be stored |
+| mode | string | strict | Restriction on directories that can be dynamically selected for a backup, the supported modes are: strict, lax and scoped |
 | backupCmd | string | | Command to be executed before the backup is done |
 | restoreCmd | string | | Command to be executed after the restore |
-| keepUploaded | bool | false | Keep locally successfully uploaded backups |
-| type | string | file | Type of the files that are backed up by this feature |
-| context | string | edge | Context of the files backed up by the feature, unique in the scope of the type |
-| mode | string | strict | Restriction on files that can be dynamically selected for a backup, the supported modes are: strict, lax and scoped |
 | singleUpload | bool | false | Forbid triggering of new backups when there is a backup in progress |
 | checksum | bool | false | Send MD5 checksum for backed up files to ensure data integrity |
 | stopTimeout | string | 30s | Time to wait for running backups to finish as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
+| keepUploaded | bool | false | Keep locally successfully uploaded backups |
+| storage | string | ./storage | Directory where backups and downloads will be stored |
+| **Upload/Download - TLS** | | | |
+| serverCert| string | | PEM encoded certificate file for secure uploads and downloads |
 | **Auto backup** | | | |
 | active | bool | false | Activate periodic backups |
 | activeFrom | string | | Time from which periodic backups should be active, in RFC 3339 format, if omitted (and `active` flag is set) current time will be used as start of the periodic backups |
@@ -33,6 +35,10 @@ To control all aspects of the file backup behavior.
 | broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the file backup will connect for the local communication, the format is: `scheme://host:port` |
 | username | string | | Username that is a part of the credentials |
 | password | string | | Password that is a part of the credentials |
+| **Local connectivity - TLS** | | | |
+| caCert | string | | PEM encoded CA certificates file |
+| cert | string | | PEM encoded certificate file to authenticate to the MQTT server/broker |
+| key | string | | PEM encoded unencrypted private key file to authenticate to the MQTT server/broker |
 | **Logging** | | | |
 | logFile | string | log/file-backup.log | Path to the file where log messages are written |
 | logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
@@ -42,11 +48,14 @@ To control all aspects of the file backup behavior.
 
 ### Example
 
-The minimal required configuration that enables backing up a directory from the file system.
+The minimal required configuration that enables backing up a directory and sets the file type to config.
 
 ```json
 {
+    "type": "config",
     "dir": "/var/tmp/file-backup",
+    "mode": "scoped",
+    "storage": "/var/lib/file-backup",
     "logFile": "/var/log/file-backup/file-backup.log"
 }
 ```
@@ -63,17 +72,18 @@ Be aware that some combinations may be incompatible.
 ```json
 {
   "featureId": "BackupAndRestore",
-  "dir": "",
-  "storage": "./storage",
-  "backupCmd": "",
-  "restoreCmd": "",
-  "keepUploaded": false,
   "type": "file",
   "context": "edge",
+  "dir": "",
   "mode": "strict",
+  "backupCmd": "",
+  "restoreCmd": "",
   "singleUpload": false,
   "checksum": false,
   "stopTimeout": "30s",
+  "keepUploaded": false,
+  "storage": "./storage",
+  "serverCert": "",
   "active": false,
   "activeFrom": "",
   "activeTill": "",
@@ -81,6 +91,9 @@ Be aware that some combinations may be incompatible.
   "broker": "tcp://localhost:1883",
   "username": "",
   "password": "",
+  "caCert": "",
+  "cert": "",
+  "key": "",
   "logFile": "log/file-backup.log",
   "logLevel": "INFO",
   "logFileCount": 5,

--- a/web/site/content/docs/references/file-backup-config.md
+++ b/web/site/content/docs/references/file-backup-config.md
@@ -3,7 +3,7 @@ title: "File backup configuration"
 type: docs
 description: >
   Customize the file backup to and from a backend storage.
-weight: 7
+weight: 6
 ---
 
 ### Properties
@@ -12,33 +12,33 @@ To control all aspects of the file backup behavior.
 
 | Property | Type | Default | Description |
 | - | - | - | - |
-| featureId | string | BackupAndRestore | Feature unique identifier in the scope of the edge digital twin. |
-| dir | string | | Directory to be backed up. |
-| storage | string | ./storage | Directory where backups and downloads will be stored. |
-| backupCmd | string | | Command to be executed before backup is done. |
-| restoreCmd | string | | Command to be executed after restore. |
-| keepUploaded | bool | false | Keep locally successfully uploaded backups. |
-| type | string | file | Type of the files that are uploaded by this feature. |
-| context | string | edge |Context of the files uploaded by the feature, unique in the scope of the type. |
-| mode | string | strict | Restriction on files that can be dynamically selected for a backup, the supported modes are: strict, lax and scoped.|
-| singleUpload | bool | false | Forbid triggering of new uploads when there is upload in progress. Trigger can be forced from the backend with the 'force' option. |
-| checksum | bool | false | Send MD5 checksum for uploaded files to ensure data integrity. Computing checksums incurs additional CPU/disk usage. |
-| stopTimeout | string | 30s | Time to wait for running uploads/backups to finish as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
-| **Auto upload** | | | |
-| active | bool | false | Activate periodic backups. |
-| activeFrom | string | | Time from which periodic backups should be active, in RFC 3339 format, if omitted (and `active` flag is set) current time will be used as start of the periodic backups. |
-| activeTill | string | | Time till which periodic backups should be active, in RFC 3339 format, if omitted (and `active` flag is set) periodic backups will be active indefinitely. |
-| period | string | 10h| Backup period as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h. |
+| featureId | string | BackupAndRestore | Feature unique identifier in the scope of the edge digital twin |
+| dir | string | | Directory to be backed up |
+| storage | string | ./storage | Directory where backups and downloads will be stored |
+| backupCmd | string | | Command to be executed before backup is done |
+| restoreCmd | string | | Command to be executed after restore |
+| keepUploaded | bool | false | Keep locally successfully uploaded backups |
+| type | string | file | Type of the files that are backed up by this feature |
+| context | string | edge | Context of the files backed up by the feature, unique in the scope of the type |
+| mode | string | strict | Restriction on files that can be dynamically selected for a backup, the supported modes are: strict, lax and scoped |
+| singleUpload | bool | false | Forbid triggering of new backups when there is backup in progress. Trigger can be forced from the backend with the 'force' option |
+| checksum | bool | false | Send MD5 checksum for backed up files to ensure data integrity |
+| stopTimeout | string | 30s | Time to wait for running backups to finish as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
+| **Auto backup** | | | |
+| active | bool | false | Activate periodic backups |
+| activeFrom | string | | Time from which periodic backups should be active, in RFC 3339 format, if omitted (and `active` flag is set) current time will be used as start of the periodic backups |
+| activeTill | string | | Time till which periodic backups should be active, in RFC 3339 format, if omitted (and `active` flag is set) periodic backups will be active indefinitely |
+| period | string | 10h| Backup period as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
 | **Local connectivity** | | | |
-| broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the file upload will connect for the local communication, the format is: `scheme://host:port`. |
-| username | string | | Username that is a part of the credentials. |
-| password | string | | Password that is a part of the credentials. |
+| broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the file backup will connect for the local communication, the format is: `scheme://host:port` |
+| username | string | | Username that is a part of the credentials |
+| password | string | | Password that is a part of the credentials |
 | **Logging** | | | |
-| logFile | string | log/file-upload.log | Path to the file where log messages are written. |
-| logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE. |
-| logFileCount | int | 5 | Log file maximum rotations count. |
-| logFileMaxAge | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files. |
-| logFileSize | int | 2 | Log file size in MB before it gets rotated. |
+| logFile | string | log/file-upload.log | Path to the file where log messages are written |
+| logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
+| logFileCount | int | 5 | Log file maximum rotations count |
+| logFileMaxAge | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files |
+| logFileSize | int | 2 | Log file size in MB before it gets rotated |
 
 
 ### Example
@@ -47,8 +47,7 @@ The minimal required configuration that backs up a directory from the file syste
 
 ```json
 {
-    "type": "directory",
-    "dir": "/var/tmp/file-backup/myBackupDirectory",
+    "dir": "/var/tmp/file-backup",
     "logFile": "/var/log/file-backup/file-backup.log"
 }
 ```

--- a/web/site/content/docs/references/file-backup-config.md
+++ b/web/site/content/docs/references/file-backup-config.md
@@ -1,0 +1,92 @@
+---
+title: "File backup configuration"
+type: docs
+description: >
+  Customize the file backup to and from a backend storage.
+weight: 7
+---
+
+### Properties
+
+To control all aspects of the file backup behavior.
+
+| Property | Type | Default | Description |
+| - | - | - | - |
+| featureId | string | BackupAndRestore | Feature unique identifier in the scope of the edge digital twin. |
+| dir | string | | Directory to be backed up. |
+| storage | string | ./storage | Directory where backups and downloads will be stored. |
+| backupCmd | string | | Command to be executed before backup is done. |
+| restoreCmd | string | | Command to be executed after restore. |
+| keepUploaded | bool | false | Keep locally successfully uploaded backups. |
+| type | string | file | Type of the files that are uploaded by this feature. |
+| context | string | edge |Context of the files uploaded by the feature, unique in the scope of the type. |
+| mode | string | strict | Restriction on files that can be dynamically selected for a backup, the supported modes are: strict, lax and scoped.|
+| singleUpload | bool | false | Forbid triggering of new uploads when there is upload in progress. Trigger can be forced from the backend with the 'force' option. |
+| checksum | bool | false | Send MD5 checksum for uploaded files to ensure data integrity. Computing checksums incurs additional CPU/disk usage. |
+| stopTimeout | string | 30s | Time to wait for running uploads/backups to finish as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
+| **Auto upload** | | | |
+| active | bool | false | Activate periodic backups. |
+| activeFrom | string | | Time from which periodic backups should be active, in RFC 3339 format, if omitted (and `active` flag is set) current time will be used as start of the periodic backups. |
+| activeTill | string | | Time till which periodic backups should be active, in RFC 3339 format, if omitted (and `active` flag is set) periodic backups will be active indefinitely. |
+| period | string | 10h| Backup period as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h. |
+| **Local connectivity** | | | |
+| broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the file upload will connect for the local communication, the format is: `scheme://host:port`. |
+| username | string | | Username that is a part of the credentials. |
+| password | string | | Password that is a part of the credentials. |
+| **Logging** | | | |
+| logFile | string | log/file-upload.log | Path to the file where log messages are written. |
+| logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE. |
+| logFileCount | int | 5 | Log file maximum rotations count. |
+| logFileMaxAge | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files. |
+| logFileSize | int | 2 | Log file size in MB before it gets rotated. |
+
+
+### Example
+
+The minimal required configuration that backs up a directory from the file system.
+
+```json
+{
+    "type": "directory",
+    "dir": "/var/tmp/file-backup/myBackupDirectory",
+    "logFile": "/var/log/file-backup/file-backup.log"
+}
+```
+
+### Template
+
+The configuration can be further adjusted according to the use case.
+The following template illustrates all possible properties with their default values.
+
+{{% warn %}}
+Be aware that some combinations may require property removal.
+{{% /warn %}}
+
+```json
+{
+  "featureId": "BackupAndRestore",
+  "dir": "",
+  "storage": "./storage",
+  "backupCmd": "",
+  "restoreCmd": "",
+  "keepUploaded": false,
+  "type": "file",
+  "context": "edge",
+  "mode": "strict",
+  "singleUpload": false,
+  "checksum": false,
+  "stopTimeout": "30s",
+  "active": false,
+  "activeFrom": "",
+  "activeTill": "",
+  "period": "10h",
+  "broker": "tcp://localhost:1883",
+  "username": "",
+  "password": "",
+  "logFile": "log/file-upload.log",
+  "logLevel": "INFO",
+  "logFileCount": 5,
+  "logFileMaxAge": 28,
+  "logFileSize": 2
+}
+```

--- a/web/site/content/docs/references/file-backup-config.md
+++ b/web/site/content/docs/references/file-backup-config.md
@@ -22,7 +22,7 @@ To control all aspects of the file backup behavior.
 | singleUpload | bool | false | Forbid triggering of new backups when there is a backup in progress |
 | checksum | bool | false | Send MD5 checksum for backed up files to ensure data integrity |
 | stopTimeout | string | 30s | Time to wait for running backups to finish as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
-| keepUploaded | bool | false | Keep locally successfully uploaded backups |
+| keepUploaded | bool | false | Keep successfully uploaded backups locally |
 | storage | string | ./storage | Directory where backups and downloads will be stored |
 | **Upload/Download - TLS** | | | |
 | serverCert| string | | PEM encoded certificate file for secure uploads and downloads |
@@ -41,7 +41,7 @@ To control all aspects of the file backup behavior.
 | key | string | | PEM encoded unencrypted private key file to authenticate to the MQTT server/broker |
 | **Logging** | | | |
 | logFile | string | log/file-backup.log | Path to the file where log messages are written |
-| logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
+| logLevel | string | INFO | All log messages at this or a higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
 | logFileCount | int | 5 | Log file maximum rotations count |
 | logFileMaxAge | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files |
 | logFileSize | int | 2 | Log file size in MB before it gets rotated |

--- a/web/site/content/docs/references/file-backup-config.md
+++ b/web/site/content/docs/references/file-backup-config.md
@@ -2,7 +2,7 @@
 title: "File backup configuration"
 type: docs
 description: >
-  Customize the file backup to and from a backend storage.
+  Customize the file backup and recovery to and from a backend storage.
 weight: 6
 ---
 
@@ -15,13 +15,13 @@ To control all aspects of the file backup behavior.
 | featureId | string | BackupAndRestore | Feature unique identifier in the scope of the edge digital twin |
 | dir | string | | Directory to be backed up |
 | storage | string | ./storage | Directory where backups and downloads will be stored |
-| backupCmd | string | | Command to be executed before backup is done |
-| restoreCmd | string | | Command to be executed after restore |
+| backupCmd | string | | Command to be executed before the backup is done |
+| restoreCmd | string | | Command to be executed after the restore |
 | keepUploaded | bool | false | Keep locally successfully uploaded backups |
 | type | string | file | Type of the files that are backed up by this feature |
 | context | string | edge | Context of the files backed up by the feature, unique in the scope of the type |
 | mode | string | strict | Restriction on files that can be dynamically selected for a backup, the supported modes are: strict, lax and scoped |
-| singleUpload | bool | false | Forbid triggering of new backups when there is backup in progress. Trigger can be forced from the backend with the 'force' option |
+| singleUpload | bool | false | Forbid triggering of new backups when there is a backup in progress |
 | checksum | bool | false | Send MD5 checksum for backed up files to ensure data integrity |
 | stopTimeout | string | 30s | Time to wait for running backups to finish as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
 | **Auto backup** | | | |
@@ -34,16 +34,15 @@ To control all aspects of the file backup behavior.
 | username | string | | Username that is a part of the credentials |
 | password | string | | Password that is a part of the credentials |
 | **Logging** | | | |
-| logFile | string | log/file-upload.log | Path to the file where log messages are written |
+| logFile | string | log/file-backup.log | Path to the file where log messages are written |
 | logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
 | logFileCount | int | 5 | Log file maximum rotations count |
 | logFileMaxAge | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files |
 | logFileSize | int | 2 | Log file size in MB before it gets rotated |
 
-
 ### Example
 
-The minimal required configuration that backs up a directory from the file system.
+The minimal required configuration that enables backing up a directory from the file system.
 
 ```json
 {
@@ -58,7 +57,7 @@ The configuration can be further adjusted according to the use case.
 The following template illustrates all possible properties with their default values.
 
 {{% warn %}}
-Be aware that some combinations may require property removal.
+Be aware that some combinations may be incompatible.
 {{% /warn %}}
 
 ```json
@@ -82,7 +81,7 @@ Be aware that some combinations may require property removal.
   "broker": "tcp://localhost:1883",
   "username": "",
   "password": "",
-  "logFile": "log/file-upload.log",
+  "logFile": "log/file-backup.log",
   "logLevel": "INFO",
   "logFileCount": 5,
   "logFileMaxAge": 28,

--- a/web/site/content/docs/references/system-metrics-config.md
+++ b/web/site/content/docs/references/system-metrics-config.md
@@ -3,7 +3,7 @@ title: "System metrics configuration"
 type: docs
 description: >
   Customize the reporting of system metrics.
-weight: 6
+weight: 7
 ---
 
 ### Properties


### PR DESCRIPTION
[#89] File backup reference guide 
 - Provided the information relevant to available configurations per a Kanto File Backup instance
 - Added an example of how to use this configuration
 - Added an example of a generic configuration

Signed-off-by: Velitchko Valkov <Velitchko.Valkov@bosch.io>