### PR TITLE
Extend documentation around configuring the suite-connector for own Hono instances

### DIFF
--- a/web/site/content/docs/getting-started/hono.md
+++ b/web/site/content/docs/getting-started/hono.md
@@ -82,6 +82,8 @@ authentication data to establish the remote connection. Update it with the follo
 }
 ```
 
+If you want to use your own Eclipse Hono instance, the value for `address` is replaced by `mqtt://<server-address>:1883`.
+
 Restart the Suite Connector service for the changes to take effect:
 
 ```shell


### PR DESCRIPTION
[#108] Extend documentation around configuring the suite-connector for own Hono instances

* Extended to documentation with a hint about configuring Kanto with own Hono instances
* Provided some information about the 'address' field of the suite-connector config,json 
* protocol needs to be specified to prevent errors
 