### PR TITLE
Ensure graceful exit of the quickstart Python script and the How-to guide Python scripts

### DIFF
--- a/quickstart/hono_commands.py
+++ b/quickstart/hono_commands.py
@@ -60,7 +60,7 @@ class CommandResponsesHandler(MessagingHandler):
         event.connection.close()
 
     def on_connection_closed(self, event):
-        print('[closing]')
+        print('[connection closed]')
         os.kill(os.getpid(), signal.SIGINT)
 
 

--- a/quickstart/hono_commands.py
+++ b/quickstart/hono_commands.py
@@ -56,6 +56,11 @@ class CommandResponsesHandler(MessagingHandler):
             print('[ok]', command)
         else:
             print('[error]')
+        event.receiver.close()
+        event.connection.close()
+
+    def on_connection_closed(self, event):
+        print('[closing]')
         os.kill(os.getpid(), signal.SIGINT)
 
 

--- a/quickstart/hono_commands_fu.py
+++ b/quickstart/hono_commands_fu.py
@@ -61,7 +61,7 @@ class CommandResponsesHandler(MessagingHandler):
             event.connection.close()
 
     def on_connection_closed(self, event):
-        print('[closing]')
+        print('[connection closed]')
         os.kill(os.getpid(), signal.SIGINT)
 
 
@@ -134,7 +134,7 @@ class EventsHandler(MessagingHandler):
                         event.connection.close()
 
     def on_connection_closed(self, event):
-        print('[closing]')
+        print('[connection closed]')
         os.kill(os.getpid(), signal.SIGINT)
 
 

--- a/quickstart/hono_commands_fu.py
+++ b/quickstart/hono_commands_fu.py
@@ -57,7 +57,12 @@ class CommandResponsesHandler(MessagingHandler):
             print('[ok]', "fu")
         else:
             print('[error]')
-            os.kill(os.getpid(), signal.SIGINT)
+            event.receiver.close()
+            event.connection.close()
+
+    def on_connection_closed(self, event):
+        print('[closing]')
+        os.kill(os.getpid(), signal.SIGINT)
 
 
 class CommandsInvoker(MessagingHandler):
@@ -88,7 +93,7 @@ class CommandsInvoker(MessagingHandler):
                                                            value=value)
         print(payload)
         msg = Message(body=payload, address='{}/{}'.format(self.address, device_id), content_type="application/json",
-                      subject="fu", reply_to=reply_to_address, correlation_id=correlation_id, id=str(uuid.uuid4()))
+                      subject=self.action, reply_to=reply_to_address, correlation_id=correlation_id, id=str(uuid.uuid4()))
         event.sender.send(msg)
         event.sender.close()
         event.connection.close()
@@ -121,10 +126,16 @@ class EventsHandler(MessagingHandler):
                     print(json.dumps(body, indent=2))
                     if body["value"]["state"] == "SUCCESS":
                         print('[successful upload]')
-                        os.kill(os.getpid(), signal.SIGINT)
+                        event.receiver.close()
+                        event.connection.close()
                     elif body["value"]["state"] == "FAILED":
                         print('[failed upload]')
-                        os.kill(os.getpid(), signal.SIGINT)
+                        event.receiver.close()
+                        event.connection.close()
+
+    def on_connection_closed(self, event):
+        print('[closing]')
+        os.kill(os.getpid(), signal.SIGINT)
 
 
 # Parse command line args

--- a/quickstart/hono_commands_su.py
+++ b/quickstart/hono_commands_su.py
@@ -80,9 +80,8 @@ class CommandResponsesHandler(MessagingHandler):
         event.connection.close()
 
     def on_connection_closed(self, event):
-        print('[closing]')
+        print('[connection closed]')
         os.kill(os.getpid(), signal.SIGINT)
-
 
 
 class CommandsInvoker(MessagingHandler):

--- a/quickstart/hono_commands_su.py
+++ b/quickstart/hono_commands_su.py
@@ -76,7 +76,13 @@ class CommandResponsesHandler(MessagingHandler):
             print('[ok]', "su")
         else:
             print('[error]')
+        event.receiver.close()
+        event.connection.close()
+
+    def on_connection_closed(self, event):
+        print('[closing]')
         os.kill(os.getpid(), signal.SIGINT)
+
 
 
 class CommandsInvoker(MessagingHandler):


### PR DESCRIPTION
[#98] Ensure graceful exit of the quickstart Python script and the How-to guide Python scripts
Fixed the issue in all scripts

Signed-off-by: Daniel Milchev <fixed-term.daniel.milchev@bosch.io>