### PR TITLE
Clean up optional "cacert" from all documentation examples

### DIFF
--- a/web/site/content/docs/getting-started/hono.md
+++ b/web/site/content/docs/getting-started/hono.md
@@ -71,7 +71,6 @@ authentication data to establish the remote connection. Update it with the follo
 
 ```json
 {
-  "caCert": "/etc/suite-connector/iothub.crt",
   "provisioningFile": "/etc/suite-connector/provisioning.json",
   "logFile": "/var/log/suite-connector/suite-connector.log",
   "address":"hono.eclipseprojects.io:1883",

--- a/web/site/content/docs/references/connectivity/suite-bootstrapping-config.md
+++ b/web/site/content/docs/references/connectivity/suite-bootstrapping-config.md
@@ -39,7 +39,7 @@ To control all aspects of the suite bootstrapping behavior.
 | tpmKey | string | | File path to the private part of the TPM 2.0 key |
 | **Logging** | | | |
 | logFile | string | log/suite-bootstrapping.log | Path to the file where log messages are written |
-| logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
+| logLevel | string | INFO | All log messages at this or a higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
 | logFileCount | int | 5 | Log file maximum rotations count |
 | logFileMaxAge | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files |
 | logFileSize | int | 2 | Log file size in MB before it gets rotated |

--- a/web/site/content/docs/references/connectivity/suite-connector-config.md
+++ b/web/site/content/docs/references/connectivity/suite-connector-config.md
@@ -41,7 +41,7 @@ To control all aspects of the suite connector behavior.
 | localKey | string | | PEM encoded unencrypted private key file to authenticate to the MQTT server/broker |
 | **Logging** | | | |
 | logFile | string | log/suite-connector.log | Path to the file where log messages are written |
-| logLevel | string | INFO | All log messages at this or higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
+| logLevel | string | INFO | All log messages at this or a higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
 | logFileCount | int | 5 | Log file maximum rotations count |
 | logFileMaxAge | int | 28 | Log file rotations maximum age in days, use 0 to not remove old log files |
 | logFileSize | int | 2 | Log file size in MB before it gets rotated |
@@ -54,7 +54,6 @@ The minimal required configuration to connect the publicly available
 ```json
 {
     "address":"hono.eclipseprojects.io:1883",
-    "caCert": "/etc/suite-connector/iothub.crt",
     "tenantId": "org.eclipse.kanto",
     "deviceId": "org.eclipse.kanto:exampleDevice",
     "authId": "org.eclipse.kanto_example",


### PR DESCRIPTION
[#92] Clean up optional "cacert" from all documentation examples

Signed-off-by: Antonia Avramova <antonia.avramova@bosch.io>