### PR TITLE
Include all Kanto components in the project's release configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,34 @@ jobs:
           path: ${{ env.BUILD_TMP }}/software-update
           ref: ${{ github.ref }}
           token: ${{ secrets.WF_AUTH }}
+      - name: Checkout local-digital-twins
+        uses: actions/checkout@v2
+        with:
+          repository: eclipse-kanto/local-digital-twins
+          path: ${{ env.BUILD_TMP }}/local-digital-twins
+          ref: ${{ github.ref }}
+          token: ${{ secrets.WF_AUTH }}
+      - name: Checkout suite-bootstrapping
+        uses: actions/checkout@v2
+        with:
+          repository: eclipse-kanto/suite-bootstrapping
+          path: ${{ env.BUILD_TMP }}/suite-bootstrapping
+          ref: ${{ github.ref }}
+          token: ${{ secrets.WF_AUTH }}
+      - name: Checkout file-backup
+        uses: actions/checkout@v2
+        with:
+          repository: eclipse-kanto/file-backup
+          path: ${{ env.BUILD_TMP }}/file-backup
+          ref: ${{ github.ref }}
+          token: ${{ secrets.WF_AUTH }}
+      - name: Checkout system-metrics
+        uses: actions/checkout@v2
+        with:
+          repository: eclipse-kanto/system-metrics
+          path: ${{ env.BUILD_TMP }}/system-metrics
+          ref: ${{ github.ref }}
+          token: ${{ secrets.WF_AUTH }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -244,6 +244,194 @@ builds:
     ldflags:
       - -s -w -X main.version={{ .Version }}
     mod_timestamp: '{{ .CommitTimestamp }}'
+    # local-digital-twins builds
+  - id: build-local-digital-twins
+    dir: ./build-tmp/local-digital-twins
+    main:  ./cmd/twins
+    binary: local-digital-twins/local-digital-twins
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=readonly
+      - -v
+      - -trimpath
+    asmflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    gcflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+  - id: build-local-digital-twins-deb
+    dir: ./build-tmp/local-digital-twins
+    main:  ./cmd/twins
+    binary: local-digital-twins
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=readonly
+      - -v
+      - -trimpath
+    asmflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    gcflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    # suite-bootstrapping builds
+  - id: build-suite-bootstrapping
+    dir: ./build-tmp/suite-bootstrapping
+    main:  ./cmd/bootstrapping
+    binary: suite-bootstrapping/suite-bootstrapping
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=readonly
+      - -v
+      - -trimpath
+    asmflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    gcflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+  - id: build-suite-bootstrapping-deb
+    dir: ./build-tmp/suite-bootstrapping
+    main:  ./cmd/bootstrapping
+    binary: suite-bootstrapping
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=readonly
+      - -v
+      - -trimpath
+    asmflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    gcflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    # file-backup builds
+  - id: build-file-backup
+    dir: ./build-tmp/file-backup
+    main:  ./
+    binary: file-backup/file-backup
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=readonly
+      - -v
+      - -trimpath
+    asmflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    gcflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+  - id: build-file-backup-deb
+    dir: ./build-tmp/file-backup
+    main:  ./
+    binary: file-backup
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=readonly
+      - -v
+      - -trimpath
+    asmflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    gcflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    # system-metrics builds
+  - id: build-system-metrics
+    dir: ./build-tmp/system-metrics
+    main:  ./cmd/metrics
+    binary: system-metrics/system-metrics
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=readonly
+      - -v
+      - -trimpath
+    asmflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    gcflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+  - id: build-system-metrics-deb
+    dir: ./build-tmp/system-metrics
+    main:  ./cmd/metrics
+    binary: system-metrics
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    flags:
+      - -mod=readonly
+      - -v
+      - -trimpath
+    asmflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    gcflags:
+      - all=-trimpath={{ .Env.GOPATH }}
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
 archives:
   - id: kanto-archive-all
     builds:
@@ -252,6 +440,10 @@ archives:
       - build-container-management-cli
       - build-file-upload
       - build-software-update
+      - build-local-digital-twins
+      - build-suite-bootstrapping
+      - build-file-backup
+      - build-system-metrics
     replacements:
       amd64: x86_64
     files:
@@ -286,6 +478,40 @@ archives:
         strip_parent: true
         info:
           mode: 0644
+      # local-digital-twins additional files
+      - src: ./build-tmp/local-digital-twins/NOTICE.md
+        dst: local-digital-twins
+        strip_parent: true
+        info:
+          mode: 0644
+      - src: ./build-tmp/local-digital-twins/cmd/twins/iothub.crt
+        dst: local-digital-twins
+        strip_parent: true
+        info:
+          mode: 0644
+      # suite-bootstrapping additional files
+      - src: ./build-tmp/suite-bootstrapping/NOTICE.md
+        dst: suite-bootstrapping
+        strip_parent: true
+        info:
+          mode: 0644
+      - src: ./build-tmp/suite-bootstrapping/cmd/bootstrapping/iothub.crt
+        dst: suite-bootstrapping
+        strip_parent: true
+        info:
+          mode: 0644
+      # file-backup additional files
+      - src: ./build-tmp/file-backup/NOTICE.md
+        dst: file-backup
+        strip_parent: true
+        info:
+          mode: 0644
+      # system-metrics additional files
+      - src: ./build-tmp/system-metrics/NOTICE.md
+        dst: system-metrics
+        strip_parent: true
+        info:
+          mode: 0644
 nfpms:
   - builds:
       - build-suite-connector-deb
@@ -293,7 +519,11 @@ nfpms:
       - build-container-management-cli-deb
       - build-file-upload-deb
       - build-software-update-deb
-    bindir: /usr/local/bin
+      - build-local-digital-twins-deb
+      - build-suite-bootstrapping-deb
+      - build-file-backup-deb
+      - build-system-metrics-deb
+    bindir: /usr/bin
     replacements:
       amd64: x86_64
     maintainer: Contributors to the Eclipse Foundation, Kanto Project <kanto-dev@eclipse.org>
@@ -410,6 +640,104 @@ nfpms:
           mode: 0644
       - src: ./build-tmp/software-update/LICENSE
         dst: /usr/share/doc/software-update/LICENSE
+        file_info:
+          mode: 0644
+        # local-digital-twins additional resources
+      - src: ./build-tmp/local-digital-twins/resources/local-digital-twins.service
+        dst: /etc/systemd/system/local-digital-twins.service
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/local-digital-twins/resources/config.json
+        dst: /etc/local-digital-twins/config.json
+        type: config
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/local-digital-twins/cmd/twins/iothub.crt
+        dst: /etc/local-digital-twins/iothub.crt
+        type: config
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/local-digital-twins/NOTICE.md
+        dst: /usr/share/doc/local-digital-twins/NOTICE.md
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/local-digital-twins/README.md
+        dst: /usr/share/doc/local-digital-twins/README.md
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/local-digital-twins/LICENSE
+        dst: /usr/share/doc/local-digital-twins/LICENSE
+        file_info:
+          mode: 0644
+        # suite-bootstrapping additional resources
+      - src: ./build-tmp/suite-bootstrapping/resources/suite-bootstrapping.service
+        dst: /etc/systemd/system/suite-bootstrapping.service
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/suite-bootstrapping/resources/config.json
+        dst: /etc/suite-bootstrapping/config.json
+        type: config
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/suite-bootstrapping/cmd/bootstrapping/iothub.crt
+        dst: /etc/suite-bootstrapping/iothub.crt
+        type: config
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/suite-bootstrapping/NOTICE.md
+        dst: /usr/share/doc/suite-bootstrapping/NOTICE.md
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/suite-bootstrapping/README.md
+        dst: /usr/share/doc/suite-bootstrapping/README.md
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/suite-bootstrapping/LICENSE
+        dst: /usr/share/doc/suite-bootstrapping/LICENSE
+        file_info:
+          mode: 0644
+        # file-backup additional resources
+      - src: ./build-tmp/file-backup/resources/file-backup.service
+        dst: /etc/systemd/system/file-backup.service
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/file-backup/resources/config.json
+        dst: /etc/file-backup/config.json
+        type: config
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/file-backup/NOTICE.md
+        dst: /usr/share/doc/file-backup/NOTICE.md
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/file-backup/README.md
+        dst: /usr/share/doc/file-backup/README.md
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/file-backup/LICENSE
+        dst: /usr/share/doc/file-backup/LICENSE
+        file_info:
+          mode: 0644
+        # system-metrics additional resources
+      - src: ./build-tmp/system-metrics/resources/system-metrics.service
+        dst: /etc/systemd/system/system-metrics.service
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/system-metrics/resources/config.json
+        dst: /etc/system-metrics/config.json
+        type: config
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/system-metrics/NOTICE.md
+        dst: /usr/share/doc/system-metrics/NOTICE.md
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/system-metrics/README.md
+        dst: /usr/share/doc/system-metrics/README.md
+        file_info:
+          mode: 0644
+      - src: ./build-tmp/system-metrics/LICENSE
+        dst: /usr/share/doc/system-metrics/LICENSE
         file_info:
           mode: 0644
 checksum:

--- a/build/postinst
+++ b/build/postinst
@@ -59,20 +59,6 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
     fi
 
     # This will only remove masks created by d-s-h on package removal.
-    deb-systemd-helper unmask 'local-digital-twins.service' >/dev/null || true
-
-    # was-enabled defaults to true, so new installations run enable.
-    if deb-systemd-helper --quiet was-enabled 'local-digital-twins.service'; then
-        # Enables the unit on first installation, creates new
-        # symlinks on upgrades if the unit file has changed.
-        deb-systemd-helper enable 'local-digital-twins.service' >/dev/null || true
-    else
-        # Update the statefile to add new symlinks (if any), which need to be
-        # cleaned up on purge. Also remove old symlinks.
-        deb-systemd-helper update-state 'local-digital-twins.service' >/dev/null || true
-    fi
-
-    # This will only remove masks created by d-s-h on package removal.
     deb-systemd-helper unmask 'file-backup.service' >/dev/null || true
 
     # was-enabled defaults to true, so new installations run enable.

--- a/build/postinst
+++ b/build/postinst
@@ -57,6 +57,49 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
         # cleaned up on purge. Also remove old symlinks.
         deb-systemd-helper update-state 'software-update.service' >/dev/null || true
     fi
+
+    # This will only remove masks created by d-s-h on package removal.
+    deb-systemd-helper unmask 'local-digital-twins.service' >/dev/null || true
+
+    # was-enabled defaults to true, so new installations run enable.
+    if deb-systemd-helper --quiet was-enabled 'local-digital-twins.service'; then
+        # Enables the unit on first installation, creates new
+        # symlinks on upgrades if the unit file has changed.
+        deb-systemd-helper enable 'local-digital-twins.service' >/dev/null || true
+    else
+        # Update the statefile to add new symlinks (if any), which need to be
+        # cleaned up on purge. Also remove old symlinks.
+        deb-systemd-helper update-state 'local-digital-twins.service' >/dev/null || true
+    fi
+
+    # This will only remove masks created by d-s-h on package removal.
+    deb-systemd-helper unmask 'file-backup.service' >/dev/null || true
+
+    # was-enabled defaults to true, so new installations run enable.
+    if deb-systemd-helper --quiet was-enabled 'file-backup.service'; then
+        # Enables the unit on first installation, creates new
+        # symlinks on upgrades if the unit file has changed.
+        deb-systemd-helper enable 'file-backup.service' >/dev/null || true
+    else
+        # Update the statefile to add new symlinks (if any), which need to be
+        # cleaned up on purge. Also remove old symlinks.
+        deb-systemd-helper update-state 'file-backup.service' >/dev/null || true
+    fi
+
+    # This will only remove masks created by d-s-h on package removal.
+    deb-systemd-helper unmask 'system-metrics.service' >/dev/null || true
+
+    # was-enabled defaults to true, so new installations run enable.
+    if deb-systemd-helper --quiet was-enabled 'system-metrics.service'; then
+        # Enables the unit on first installation, creates new
+        # symlinks on upgrades if the unit file has changed.
+        deb-systemd-helper enable 'system-metrics.service' >/dev/null || true
+    else
+        # Update the statefile to add new symlinks (if any), which need to be
+        # cleaned up on purge. Also remove old symlinks.
+        deb-systemd-helper update-state 'system-metrics.service' >/dev/null || true
+    fi
+    
 fi
 # End automatically added section
 # Automatically added by dh_systemd_start/12.1.1bv2019.0b1
@@ -72,6 +115,10 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
         deb-systemd-invoke $_dh_action 'container-management.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'file-upload.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'software-update.service' >/dev/null || true
+        deb-systemd-invoke $_dh_action 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-invoke $_dh_action 'suite-bootstrapping.service' >/dev/null || true
+        deb-systemd-invoke $_dh_action 'file-backup.service' >/dev/null || true
+        deb-systemd-invoke $_dh_action 'system-metrics.service' >/dev/null || true
     fi
 fi
 # End automatically added section

--- a/build/postrm
+++ b/build/postrm
@@ -11,6 +11,7 @@ if [ "$1" = "remove" ]; then
         deb-systemd-helper mask 'container-management.service' >/dev/null || true
         deb-systemd-helper mask 'suite-connector.service' >/dev/null || true
         deb-systemd-helper mask 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-helper mask 'suite-bootstrapping.service' >/dev/null || true
         deb-systemd-helper mask 'file-backup.service' >/dev/null || true
         deb-systemd-helper mask 'system-metrics.service' >/dev/null || true
     fi
@@ -28,6 +29,8 @@ if [ "$1" = "purge" ]; then
         deb-systemd-helper unmask 'suite-connector.service' >/dev/null || true
         deb-systemd-helper purge 'local-digital-twins.service' >/dev/null || true
         deb-systemd-helper unmask 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-helper purge 'suite-bootstrapping.service' >/dev/null || true
+        deb-systemd-helper unmask 'suite-bootstrapping.service' >/dev/null || true
         deb-systemd-helper purge 'file-backup.service' >/dev/null || true
         deb-systemd-helper unmask 'file-backup.service' >/dev/null || true
         deb-systemd-helper purge 'system-metrics.service' >/dev/null || true

--- a/build/postrm
+++ b/build/postrm
@@ -10,6 +10,9 @@ if [ "$1" = "remove" ]; then
         deb-systemd-helper mask 'file-upload.service' >/dev/null || true
         deb-systemd-helper mask 'container-management.service' >/dev/null || true
         deb-systemd-helper mask 'suite-connector.service' >/dev/null || true
+        deb-systemd-helper mask 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-helper mask 'file-backup.service' >/dev/null || true
+        deb-systemd-helper mask 'system-metrics.service' >/dev/null || true
     fi
 fi
 
@@ -23,6 +26,12 @@ if [ "$1" = "purge" ]; then
         deb-systemd-helper unmask 'container-management.service' >/dev/null || true
         deb-systemd-helper purge 'suite-connector.service' >/dev/null || true
         deb-systemd-helper unmask 'suite-connector.service' >/dev/null || true
+        deb-systemd-helper purge 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-helper unmask 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-helper purge 'file-backup.service' >/dev/null || true
+        deb-systemd-helper unmask 'file-backup.service' >/dev/null || true
+        deb-systemd-helper purge 'system-metrics.service' >/dev/null || true
+        deb-systemd-helper unmask 'system-metrics.service' >/dev/null || true
     fi
 fi
 if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then

--- a/build/prerm
+++ b/build/prerm
@@ -4,5 +4,8 @@ if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
     deb-systemd-invoke stop 'file-upload.service' >/dev/null || true
     deb-systemd-invoke stop 'container-management.service' >/dev/null || true
     deb-systemd-invoke stop 'suite-connector.service' >/dev/null || true
+    deb-systemd-invoke stop 'local-digital-twins.service' >/dev/null || true
+    deb-systemd-invoke stop 'file-backup.service' >/dev/null || true
+    deb-systemd-invoke stop 'system-metrics.service' >/dev/null || true
 fi
 # End automatically added section

--- a/build/prerm
+++ b/build/prerm
@@ -5,6 +5,7 @@ if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
     deb-systemd-invoke stop 'container-management.service' >/dev/null || true
     deb-systemd-invoke stop 'suite-connector.service' >/dev/null || true
     deb-systemd-invoke stop 'local-digital-twins.service' >/dev/null || true
+    deb-systemd-invoke stop 'suite-bootstrapping.service' >/dev/null || true
     deb-systemd-invoke stop 'file-backup.service' >/dev/null || true
     deb-systemd-invoke stop 'system-metrics.service' >/dev/null || true
 fi


### PR DESCRIPTION
[#122] Include all Kanto components in the project's release configuration
Added the building blocks to ".goreleaser.yaml", modified the build classes and "release.yaml".

Signed-off-by: Daniel Milchev <fixed-term.daniel.milchev@bosch.io>