### PR TITLE
Go Releaser release failing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -546,11 +546,11 @@ nfpms:
           - containerd.io | containerd
           - mosquitto
           - iptables
-       rpm:
-         dependencies:
-           - containerd
-           - mosquitto
-           - iptables
+      rpm:
+        dependencies:
+          - containerd
+          - mosquitto
+          - iptables
     contents:
       # suite-connector additional resources
       - src: ./build-tmp/suite-connector/resources/suite-connector.service


### PR DESCRIPTION
[#130] Go Releaser release failing

Fixed improper spacing in the configuration YAML file.

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>