### PR TITLE
Include lease ID management in the container management reference guide

### DIFF
--- a/web/site/content/docs/references/containers/container-manager-config.md
+++ b/web/site/content/docs/references/containers/container-manager-config.md
@@ -27,6 +27,7 @@ To control all aspects of the container manager behavior.
 | runc_runtime | string | io.containerd.runc.v2 | Runc communication mode, the possible values are: io.containerd.runtime.v1.linux, io.containerd.runc.v1 and io.containerd.runc.v2 |
 | image_expiry | string | 744h | Time period for the cached images and content to be kept in the form of e.g. 72h3m0.5s |
 | image_expiry_disable | bool | false | Disable expiry management of cached images and content, must be used with caution as it may lead to large memory volumes being persistently allocated |
+| lease_id | string | kanto-cm.lease | Lease identifier to be used for container resources persistence |
 | **Registry access - secure** | | | |
 | user_id | string | | User unique identifier to authenticate to the image registry |
 | password | string | | Password to authenticate to the image registry |
@@ -118,6 +119,7 @@ Be aware that in the registry configuration the host (used as a key) has to be s
         "runc_runtime": "io.containerd.runc.v2",
         "image_expiry": "744h",
         "image_expiry_disable": false,
+        "lease_id": "kanto-cm.lease",
         "registry_configurations": {
             "": {
                 "credentials": {


### PR DESCRIPTION
[#132] Include lease ID management in the container management reference guide

- lease_id is added in the properties table and in the template

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>