### PR TITLE
Shutdown order for services must go in opposite direction of starting for the deb package

### DIFF
--- a/build/postrm
+++ b/build/postrm
@@ -6,19 +6,23 @@ fi
 # Automatically added by dh_systemd_enable/12.1.1bv2019.0b1
 if [ "$1" = "remove" ]; then
     if [ -x "/usr/bin/deb-systemd-helper" ]; then
+        deb-systemd-helper mask 'system-metrics.service' >/dev/null || true
+        deb-systemd-helper mask 'file-backup.service' >/dev/null || true
         deb-systemd-helper mask 'software-update.service' >/dev/null || true
         deb-systemd-helper mask 'file-upload.service' >/dev/null || true
         deb-systemd-helper mask 'container-management.service' >/dev/null || true
         deb-systemd-helper mask 'suite-connector.service' >/dev/null || true
         deb-systemd-helper mask 'local-digital-twins.service' >/dev/null || true
         deb-systemd-helper mask 'suite-bootstrapping.service' >/dev/null || true
-        deb-systemd-helper mask 'file-backup.service' >/dev/null || true
-        deb-systemd-helper mask 'system-metrics.service' >/dev/null || true
     fi
 fi
 
 if [ "$1" = "purge" ]; then
     if [ -x "/usr/bin/deb-systemd-helper" ]; then
+        deb-systemd-helper purge 'system-metrics.service' >/dev/null || true
+        deb-systemd-helper unmask 'system-metrics.service' >/dev/null || true
+        deb-systemd-helper purge 'file-backup.service' >/dev/null || true
+        deb-systemd-helper unmask 'file-backup.service' >/dev/null || true
         deb-systemd-helper purge 'software-update.service' >/dev/null || true
         deb-systemd-helper unmask 'software-update.service' >/dev/null || true
         deb-systemd-helper purge 'file-upload.service' >/dev/null || true
@@ -31,10 +35,6 @@ if [ "$1" = "purge" ]; then
         deb-systemd-helper unmask 'local-digital-twins.service' >/dev/null || true
         deb-systemd-helper purge 'suite-bootstrapping.service' >/dev/null || true
         deb-systemd-helper unmask 'suite-bootstrapping.service' >/dev/null || true
-        deb-systemd-helper purge 'file-backup.service' >/dev/null || true
-        deb-systemd-helper unmask 'file-backup.service' >/dev/null || true
-        deb-systemd-helper purge 'system-metrics.service' >/dev/null || true
-        deb-systemd-helper unmask 'system-metrics.service' >/dev/null || true
     fi
 fi
 if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then

--- a/build/prerm
+++ b/build/prerm
@@ -1,12 +1,12 @@
 # Automatically added by dh_systemd_start/12.1.1bv2019.0b1
 if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
+    deb-systemd-invoke stop 'system-metrics.service' >/dev/null || true
+    deb-systemd-invoke stop 'file-backup.service' >/dev/null || true
     deb-systemd-invoke stop 'software-update.service' >/dev/null || true
     deb-systemd-invoke stop 'file-upload.service' >/dev/null || true
     deb-systemd-invoke stop 'container-management.service' >/dev/null || true
     deb-systemd-invoke stop 'suite-connector.service' >/dev/null || true
     deb-systemd-invoke stop 'local-digital-twins.service' >/dev/null || true
     deb-systemd-invoke stop 'suite-bootstrapping.service' >/dev/null || true
-    deb-systemd-invoke stop 'file-backup.service' >/dev/null || true
-    deb-systemd-invoke stop 'system-metrics.service' >/dev/null || true
 fi
 # End automatically added section


### PR DESCRIPTION
[#133] Shutdown order for services must go in opposite direction of starting for the deb package
Reordered the services

Signed-off-by: Daniel Milchev <fixed-term.daniel.milchev@bosch.io>