### PR TITLE
Shutdown order for services must go in opposite direction of starting for the deb package 

### DIFF
--- a/build/postinst
+++ b/build/postinst
@@ -17,6 +17,20 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
     fi
 
     # This will only remove masks created by d-s-h on package removal.
+    deb-systemd-helper unmask 'local-digital-twins.service' >/dev/null || true
+
+    # Update the statefile to add new symlinks (if any), which need to be
+    # cleaned up on purge. Also remove old symlinks.
+    deb-systemd-helper update-state 'local-digital-twins.service' >/dev/null || true
+
+    # This will only remove masks created by d-s-h on package removal.
+    deb-systemd-helper unmask 'suite-bootstrapping.service' >/dev/null || true
+
+    # Update the statefile to add new symlinks (if any), which need to be
+    # cleaned up on purge. Also remove old symlinks.
+    deb-systemd-helper update-state 'suite-bootstrapping.service' >/dev/null || true
+
+    # This will only remove masks created by d-s-h on package removal.
     deb-systemd-helper unmask 'container-management.service' >/dev/null || true
 
     # was-enabled defaults to true, so new installations run enable.
@@ -98,11 +112,11 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
             _dh_action=start
         fi
         deb-systemd-invoke $_dh_action 'suite-connector.service' >/dev/null || true
+        deb-systemd-invoke $_dh_action 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-invoke $_dh_action 'suite-bootstrapping.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'container-management.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'file-upload.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'software-update.service' >/dev/null || true
-        deb-systemd-invoke $_dh_action 'local-digital-twins.service' >/dev/null || true
-        deb-systemd-invoke $_dh_action 'suite-bootstrapping.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'file-backup.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'system-metrics.service' >/dev/null || true
     fi

--- a/build/postrm
+++ b/build/postrm
@@ -11,9 +11,9 @@ if [ "$1" = "remove" ]; then
         deb-systemd-helper mask 'software-update.service' >/dev/null || true
         deb-systemd-helper mask 'file-upload.service' >/dev/null || true
         deb-systemd-helper mask 'container-management.service' >/dev/null || true
-        deb-systemd-helper mask 'suite-connector.service' >/dev/null || true
-        deb-systemd-helper mask 'local-digital-twins.service' >/dev/null || true
         deb-systemd-helper mask 'suite-bootstrapping.service' >/dev/null || true
+        deb-systemd-helper mask 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-helper mask 'suite-connector.service' >/dev/null || true
     fi
 fi
 
@@ -29,12 +29,12 @@ if [ "$1" = "purge" ]; then
         deb-systemd-helper unmask 'file-upload.service' >/dev/null || true
         deb-systemd-helper purge 'container-management.service' >/dev/null || true
         deb-systemd-helper unmask 'container-management.service' >/dev/null || true
-        deb-systemd-helper purge 'suite-connector.service' >/dev/null || true
-        deb-systemd-helper unmask 'suite-connector.service' >/dev/null || true
-        deb-systemd-helper purge 'local-digital-twins.service' >/dev/null || true
-        deb-systemd-helper unmask 'local-digital-twins.service' >/dev/null || true
         deb-systemd-helper purge 'suite-bootstrapping.service' >/dev/null || true
         deb-systemd-helper unmask 'suite-bootstrapping.service' >/dev/null || true
+        deb-systemd-helper purge 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-helper unmask 'local-digital-twins.service' >/dev/null || true
+        deb-systemd-helper purge 'suite-connector.service' >/dev/null || true
+        deb-systemd-helper unmask 'suite-connector.service' >/dev/null || true
     fi
 fi
 if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then

--- a/build/prerm
+++ b/build/prerm
@@ -5,8 +5,8 @@ if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
     deb-systemd-invoke stop 'software-update.service' >/dev/null || true
     deb-systemd-invoke stop 'file-upload.service' >/dev/null || true
     deb-systemd-invoke stop 'container-management.service' >/dev/null || true
-    deb-systemd-invoke stop 'suite-connector.service' >/dev/null || true
-    deb-systemd-invoke stop 'local-digital-twins.service' >/dev/null || true
     deb-systemd-invoke stop 'suite-bootstrapping.service' >/dev/null || true
+    deb-systemd-invoke stop 'local-digital-twins.service' >/dev/null || true
+    deb-systemd-invoke stop 'suite-connector.service' >/dev/null || true
 fi
 # End automatically added section


### PR DESCRIPTION
[#133] Shutdown order for services must go in opposite direction of starting for the deb package

Fixed ordering of stopping and purging of the connectivity components. Fixed start attempts for the connectivity components. Added unmasking and state update for the disabled components on installation.

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>