### PR TITLE
Updated the getting started documentation resources to cover the upcoming M2 release

### DIFF
--- a/web/site/content/docs/getting-started/dmp.md
+++ b/web/site/content/docs/getting-started/dmp.md
@@ -33,8 +33,10 @@ on the right-hand side
 
 * **\<your-namespace\>:\<gateway-name\>** - the gateway you have provisioned with _Features_, e.g.
     * ConnectionStatus 
-    * Autouploadable
     * SoftwareUpdatable
+    * AutoUploadable
+    * BackupAndRestore
+    * Metrics
 * **\<your-namespace\>:\<gateway-name\>:edge:containers** - a virtual one that provides the edge container management _Features_, e.g.
     * ConnectionStatus
     * ContainerFactory

--- a/web/site/content/docs/getting-started/install.md
+++ b/web/site/content/docs/getting-started/install.md
@@ -21,8 +21,8 @@ at <a href="https://github.com/eclipse-kanto/kanto/releases" target="_blank">the
 Download and install it via executing the following (adjusted to your package name):
 
 ```shell
-wget https://github.com/eclipse-kanto/kanto/releases/download/v0.1.0-M1/kanto_0.1.0-M1_linux_x86_64.deb && \
-sudo apt install ./kanto_0.1.0-M1_linux_x86_64.deb
+wget https://github.com/eclipse-kanto/kanto/releases/download/v0.1.0-M2/kanto_0.1.0-M2_linux_x86_64.deb && \
+sudo apt install ./kanto_0.1.0-M2_linux_x86_64.deb
 ```
 
 ### Verify
@@ -35,7 +35,9 @@ systemctl status \
 suite-connector.service \
 container-management.service \
 software-update.service \
-file-upload.service 
+file-upload.service \
+file-backup.service \
+system-metrics.service
 ```
 
 All listed services must be in an active running state.


### PR DESCRIPTION
[#141] Update "Install Eclipse Kanto" guide to cover the incoming M2 release

Applied the necessary changes regarding new functionalities and released version.

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>