### PR TITLE
Add thingsDb in the example of local digital twins configuration

### DIFF
--- a/web/site/content/docs/references/connectivity/suite-bootstrapping-config.md
+++ b/web/site/content/docs/references/connectivity/suite-bootstrapping-config.md
@@ -51,7 +51,7 @@ The minimal required configuration to connect the publicly available
 
 ```json
 {
-    "address":"hono.eclipseprojects.io:1883",
+    "address": "hono.eclipseprojects.io:1883",
     "tenantId": "org.eclipse.kanto",
     "deviceId": "org.eclipse.kanto:exampleDevice",
     "authId": "org.eclipse.kanto_example",

--- a/web/site/content/docs/references/connectivity/suite-connector-config.md
+++ b/web/site/content/docs/references/connectivity/suite-connector-config.md
@@ -53,7 +53,7 @@ The minimal required configuration to connect the publicly available
 
 ```json
 {
-    "address":"hono.eclipseprojects.io:1883",
+    "address": "hono.eclipseprojects.io:1883",
     "tenantId": "org.eclipse.kanto",
     "deviceId": "org.eclipse.kanto:exampleDevice",
     "authId": "org.eclipse.kanto_example",

--- a/web/site/content/docs/references/local-digital-twins-config.md
+++ b/web/site/content/docs/references/local-digital-twins-config.md
@@ -53,12 +53,12 @@ The minimal required configuration to enable the local digital twins and their s
 
 ```json
 {
-    "thingsDb": "/var/lib/local-digital-twins/thing.db",
     "address": "hono.eclipseprojects.io:1883",
     "tenantId": "org.eclipse.kanto",
     "deviceId": "org.eclipse.kanto:exampleDevice",
     "authId": "org.eclipse.kanto_example",
     "password": "secret",
+    "thingsDb": "/var/lib/local-digital-twins/thing.db",
     "logFile": "/var/log/local-digital-twins/local-digital-twins.log"
 }
 ```

--- a/web/site/content/docs/references/local-digital-twins-config.md
+++ b/web/site/content/docs/references/local-digital-twins-config.md
@@ -53,7 +53,8 @@ The minimal required configuration to enable the local digital twins and their s
 
 ```json
 {
-    "address":"hono.eclipseprojects.io:1883",
+    "thingsDb": "/var/lib/local-digital-twins/thing.db",
+    "address": "hono.eclipseprojects.io:1883",
     "tenantId": "org.eclipse.kanto",
     "deviceId": "org.eclipse.kanto:exampleDevice",
     "authId": "org.eclipse.kanto_example",


### PR DESCRIPTION
[#152] Add thingsDb in the example of local digital twins configuration

- thingsDb has been added to the local digital twins configuration
- formatting of the configuration examples has been aligned between: local digital twins, suite connector and suite bootstrapping

Signed-off-by: Antonia Avramova <antonia.avramova@bosch.io>