### PR TITLE
Improved community onboarding and engagement public info

### DIFF
--- a/web/site/assets/scss/main.scss
+++ b/web/site/assets/scss/main.scss
@@ -14,3 +14,7 @@
 @import "logo";
 @import "screen";
 @import "shortcodes";
+
+html {
+    overflow-y: scroll;
+}

--- a/web/site/config.toml
+++ b/web/site/config.toml
@@ -128,22 +128,46 @@ sidebar_menu_truncate = 80
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
-    name = "Eclipse Kanto Project"
+    name = "Eclipse Kanto project"
     url = "https://projects.eclipse.org/projects/iot.kanto"
     icon = "fas fa-external-link-alt"
-    desc = "Eclipse Kanto project home page"
-
+    desc = "Welcome to our Eclipse IoT home"
+[[params.links.user]]
+  name = "Stack Overflow"
+  url = "https://stackoverflow.com/questions/tagged/eclipse-kanto"
+  icon = "fab fa-stack-overflow"
+  desc = "Ask practical questions for eclipse-kanto"
+[[params.links.user]]
+    name = "YouTube"
+    url = "https://www.youtube.com/watch?v=bMN_ZiUS3Bc"
+    icon = "fab fa-youtube"
+    desc = "From \"Can't\" to \"Can\" with Kanto"
+[[params.links.user]]
+    name = "Newsletter"
+    url = "https://newsroom.eclipse.org/eclipse-newsletter/2022/february/five-ways-eclipse-kanto-accelerates-iot-edge-development"
+    icon = "fas fa-book-open"
+    desc = "Five Ways Eclipse Kanto Accelerates IoT Edge Development"
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
     name = "GitHub"
     url = "https://github.com/eclipse-kanto"
     icon = "fab fa-github"
-    desc = "Eclipse Kanto GitHub organization"
+    desc = "Development takes place here!"
+[[params.links.developer]]
+    name = "Releases"
+    url = "https://github.com/eclipse-kanto/kanto/releases"
+    icon = "fas fa-rocket"
+    desc = "Try out the latest release!"
+[[params.links.developer]]
+    name = "Task board"
+    url = "https://github.com/orgs/eclipse-kanto/projects/1/views/1"
+    icon = "fas fa-clipboard-list"
+    desc = "Check out the roadmap and ongoing work"
 [[params.links.developer]]
     name = "Developer mailing list"
     url = "https://accounts.eclipse.org/mailing-list/kanto-dev"
     icon = "fa fa-envelope"
-    desc = "Eclipse Kanto developer discussions"
+    desc = "Join developer discussions"
 
 # Eclipse relevant links. These will show up at the bottom footer line.
 [[params.links.eclipse]]
@@ -173,13 +197,6 @@ sidebar_menu_truncate = 80
 [[params.links.eclipse]]
   url = "https://eclipse.org/security/"
   name = "Report a Vulnerability"
-
-# Additional menu items
-[[menu.main]]
-identifier = "GitHub"
-name = "GitHub"
-url = "https://github.com/eclipse-kanto"
-weight = 60
 
 [taxonomies]
 tag = "tags"

--- a/web/site/content/about/_index.html
+++ b/web/site/content/about/_index.html
@@ -3,7 +3,7 @@ title: "About"
 linkTitle: "About"
 menu:
   main:
-    weight: 10
+    weight: 2
 description: >
   About Eclipse Kanto features.
 aliases: ["/about/"]

--- a/web/site/content/community/_index.md
+++ b/web/site/content/community/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Community"
+linkTitle: "Community"
+type: community
+menu:
+  main:
+    weight: 4
+---

--- a/web/site/content/docs/_index.md
+++ b/web/site/content/docs/_index.md
@@ -3,6 +3,6 @@ linkTitle: "Documentation"
 type: docs
 menu:
   main:
-    weight: 10
+    weight: 3
 ---
 

--- a/web/site/layouts/partials/community_links.html
+++ b/web/site/layouts/partials/community_links.html
@@ -1,0 +1,30 @@
+{{ $links := .Site.Params.links }}
+
+<section class="row td-box td-box--height-auto linkbox">
+    <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+        <h2>{{ T "community_learn" }}</h2>
+        <p>{{ T "community_using" . }}</p>
+        {{ with index $links "user"}}
+        {{ template "community-links-list" . }}
+        {{ end }}
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+        <h2>{{ T "community_develop" }}</h2>
+        <p>{{ T "community_contribute" . }}</p>
+        {{ with index $links "developer"}}
+        {{ template "community-links-list" . }}
+        {{ end }}
+        <p>{{ T "community_how_to" . }} <a target="_blank" href="https://github.com/eclipse-kanto/kanto/blob/main/CONTRIBUTING.md">{{ T "community_guideline" }}</a>
+    </div>
+</section>
+
+{{ define "community-links-list" }}
+<ul>
+    {{ range . }}
+    <li title="{{ .name }}">
+        <a target="_blank" rel="noopener" href="{{ .url }}"><i class="{{ .icon }}"></i> {{ .name }}:</a>
+        {{ .desc }}
+    </li>
+    {{ end }}
+</ul>
+{{ end }}

--- a/web/site/layouts/shortcodes/home-about.html
+++ b/web/site/layouts/shortcodes/home-about.html
@@ -20,4 +20,16 @@
 			{{ end }}
 		</div>
 	</div>
+	<div class="row justify-content-center td-box--100 p-3">
+		<div class="col justify-content-center p-3">
+			<a href="docs/getting-started/install" class="kanto-button kanto-feature text-uppercase font-weight-bold">
+				Get started <i class="pl-3 fas fa-arrow-right"></i>
+			</a>
+		</div>
+		<div class="col justify-content-center p-3">
+			<a href="community" class="kanto-button kanto-feature text-uppercase font-weight-bold">
+				Get involved <i class="pl-3 fas fa-arrow-right"></i>
+			</a>
+		</div>
+	</div>
 </section>


### PR DESCRIPTION
[#159] Improve community onboarding and engagement public info

Added a dedicated Community page covering the social, development and contributing links and information. Fixed main menu pages orger accordingly.
Added Get started and Releases button in the home page to easy and enable quick hands-ons.

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>