### PR TITLE
Fixed typos in the how-to guides documentation pages and markdown files

### DIFF
--- a/web/site/content/docs/getting-started/hono.md
+++ b/web/site/content/docs/getting-started/hono.md
@@ -6,7 +6,7 @@ description: >
 weight: 2
 ---
 
-Following the steps below you will connect your first device to a publicly
+By following the steps below you will connect your first device to a publicly
 available {{% refn "https://www.eclipse.org/hono/sandbox/" %}}Eclipse Hono sandbox{{% /refn %}} using Eclipse Kanto.
 A couple of simple Eclipse Hono northbound business applications written in Python are provided to explore the capabilities for
 remotely managing and monitoring your edge device.

--- a/web/site/content/docs/how-to-guides/backup-restore-files.md
+++ b/web/site/content/docs/how-to-guides/backup-restore-files.md
@@ -6,7 +6,7 @@ description: >
 weight: 3
 ---
 
-Following the steps below you will back up a simple text file to an HTTP file server
+By following the steps below you will back up a simple text file to an HTTP file server
 and then restore it back via a publicly available Eclipse Hono sandbox using Eclipse Kanto.
 A simple Eclipse Hono northbound business application written in Python is
 provided to explore the capabilities for remotely backing up and restoring files.

--- a/web/site/content/docs/how-to-guides/monitor-system-metrics.md
+++ b/web/site/content/docs/how-to-guides/monitor-system-metrics.md
@@ -6,7 +6,7 @@ description: >
 weight: 4
 ---
 
-Following the steps below you will be able to monitor the system metrics from your edge device
+By following the steps below you will be able to monitor the system metrics from your edge device
 via a publicly available Eclipse Hono sandbox using Eclipse Kanto. A simple Eclipse Hono
 northbound business application written in Python is provided to explore the capabilities
 for remotely monitoring the CPU and memory utilization.

--- a/web/site/content/docs/how-to-guides/monitor-system-metrics.md
+++ b/web/site/content/docs/how-to-guides/monitor-system-metrics.md
@@ -43,8 +43,7 @@ To ensure that all steps in this guide can be executed, you need:
   wget https://github.com/eclipse-kanto/kanto/raw/main/quickstart/hono_commands_sm.py
   ```
 
-
-### Monitor System Metrics
+### Monitor system metrics
 
 To explore the system metrics, we will use a Python script to request and monitor the
 CPU and memory utilization. The location where the Python application will run does

--- a/web/site/content/docs/how-to-guides/update-software.md
+++ b/web/site/content/docs/how-to-guides/update-software.md
@@ -6,7 +6,7 @@ description: >
 weight: 1
 ---
 
-Following the steps below you will install a{{% refn "https://www.gnu.org/software/hello/" %}}`hello`{{% /refn %}}
+By following the steps below you will install a{{% refn "https://www.gnu.org/software/hello/" %}}`hello`{{% /refn %}}
 Debian package via a publicly available Eclipse Hono sandbox using Eclipse Kanto.
 A couple of simple Eclipse Hono northbound business applications written in Python are provided to explore
 the capabilities for remotely installing and monitoring.

--- a/web/site/content/docs/how-to-guides/upload-files.md
+++ b/web/site/content/docs/how-to-guides/upload-files.md
@@ -40,7 +40,6 @@ To ensure that all steps in this guide can be executed, you need:
   wget https://github.com/eclipse-kanto/kanto/raw/main/quickstart/hono_commands_fu.py
   ```
 
-
 ### Upload log file
 
 By default, all files in `/var/tmp/file-upload/` directory can be uploaded.
@@ -69,7 +68,7 @@ python3 hono_commands_fu.py -t demo -d demo:device
 
 ### Verify
 
-You can check out that the log file is on your HTTP file server listing the content of `servefile` working directory.
+You can check out that the log file is on your HTTP file server by listing the content of `servefile` working directory.
 
 ### Clean up
 

--- a/web/site/content/docs/how-to-guides/upload-files.md
+++ b/web/site/content/docs/how-to-guides/upload-files.md
@@ -6,7 +6,7 @@ description: >
 weight: 2
 ---
 
-Following the steps below you will upload an example log file to your HTTP file server
+By following the steps below you will upload an example log file to your HTTP file server
 via a publicly available Eclipse Hono sandbox using Eclipse Kanto.
 A simple Eclipse Hono northbound business application written in Python is
 provided to explore the capabilities for remotely uploading and monitoring.


### PR DESCRIPTION
[#163]  Fix typos in documentation pages of the how-to guides

- changed file name of system metrics markdown file
- removed excessive new lines
- fixed typo in the "Verify" part of the file upload documentation page
- fixed phrase "system metrics" to be lowercase
- fixed `Following the steps` to `By following the steps`

Signed-off-by: Ognian Baruh <Ognyan.Baruh@bosch.io>