### PR TITLE
Missing software update configuration properties

### DIFF
--- a/web/site/content/docs/references/software-update-config.md
+++ b/web/site/content/docs/references/software-update-config.md
@@ -17,8 +17,8 @@ To control all aspects of the software update behavior.
 | artifactType | string | archive | Type of the artifact that is to be processed: archive or plain |
 | install | string[] | | Absolute path to the install script/command and an optional sequence of additional flags/parameters |
 | storageLocation | string | ./ | Path to the storage directory where the working files are stored |
-| installDirs | string[] | | Local file system directories where the artifacts will be stored |
-| mode | string | strict | Restriction where the artifacts can be stored on the local file system, the supported modes are: strict, lax and scope |
+| installDirs | string[] | | File system directories where the local artifacts will be stored |
+| mode | string | strict | Restriction where the local artifacts can be stored on the file system, the supported modes are: strict, lax and scope |
 | **Download** | | | |
 | downloadRetryCount | int| 0 | Number of retries, in case of a failed download |
 | downloadRetryInterval | string | 5s | Interval between retries, in case of a failed download as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |

--- a/web/site/content/docs/references/software-update-config.md
+++ b/web/site/content/docs/references/software-update-config.md
@@ -17,7 +17,7 @@ To control all aspects of the software update behavior.
 | artifactType | string | archive | Type of the artifact that is to be processed: archive or plain |
 | install | string[] | | Absolute path to the install script/command and an optional sequence of additional flags/parameters |
 | storageLocation | string | ./ | Path to the storage directory where the working files are stored |
-| installDirs | string[] | | File system directories where the local artifacts will be stored |
+| installDirs | string[] | | File system directories where the local artifacts are stored |
 | mode | string | strict | Restriction where the local artifacts can be stored on the file system, the supported modes are: strict, lax and scope |
 | **Download** | | | |
 | downloadRetryCount | int| 0 | Number of retries, in case of a failed download |
@@ -61,9 +61,9 @@ The following template illustrates all possible properties with their default va
     "storageLocation": "./",
     "installDirs": [],
     "mode": "strict",
-    "serverCert": "",
     "downloadRetryCount": 0,
     "downloadRetryInterval": "5s",
+    "serverCert": "",
     "broker": "tcp://localhost:1883",
     "username": "",
     "password": "",

--- a/web/site/content/docs/references/software-update-config.md
+++ b/web/site/content/docs/references/software-update-config.md
@@ -17,13 +17,13 @@ To control all aspects of the software update behavior.
 | artifactType | string | archive | Type of the artifact that is to be processed: archive or plain |
 | install | string[] | | Absolute path to the install script/command and an optional sequence of additional flags/parameters |
 | storageLocation | string | ./ | Path to the storage directory where the working files are stored |
-| installDirs | string[] | | Directories where the artifacts will be stored |
-| mode | string | strict | Restriction where the artifacts can be located, the supported modes are: strict, lax and scope |
-| **Download - TLS** | | | |
-| serverCert | string | | PEM encoded certificate file for secure downloads |
+| installDirs | string[] | | Local file system directories where the artifacts will be stored |
+| mode | string | strict | Restriction where the artifacts can be stored on the local file system, the supported modes are: strict, lax and scope |
 | **Download** | | | |
 | downloadRetryCount | int| 0 | Number of retries, in case of a failed download |
 | downloadRetryInterval | string | 5s | Interval between retries, in case of a failed download as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
+| **Download - TLS** | | | |
+| serverCert | string | | PEM encoded certificate file for secure downloads |
 | **Local connectivity** | | | |
 | broker | string | tcp://localhost:1883 | Address of the MQTT server/broker that the software update will connect for the local communication, the format is: `scheme://host:port` |
 | username | string | | Username that is a part of the credentials |

--- a/web/site/content/docs/references/software-update-config.md
+++ b/web/site/content/docs/references/software-update-config.md
@@ -17,6 +17,10 @@ To control all aspects of the software update behavior.
 | artifactType | string | archive | Type of the artifact that is to be processed: archive or plain |
 | install | string[] | | Absolute path to the install script/command and an optional sequence of additional flags/parameters |
 | storageLocation | string | ./ | Path to the storage directory where the working files are stored |
+| installDirs | string[] | | Directories where the artifacts will be stored |
+| mode | string | strict | Restriction where the artifacts can be located, the supported modes are: strict, lax and scope |
+| **Download - TLS** | | | |
+| serverCert | string | | PEM encoded certificate file for secure downloads |
 | **Download** | | | |
 | downloadRetryCount | int| 0 | Number of retries, in case of a failed download |
 | downloadRetryInterval | string | 5s | Interval between retries, in case of a failed download as a sequence of decimal numbers, each with optional fraction and a unit suffix, such as: 300ms, 1.5h, 10m30s, etc., time units are: ns, us (or µs), ms, s, m, h |
@@ -55,6 +59,9 @@ The following template illustrates all possible properties with their default va
     "artifactType": "archive",
     "install": [],
     "storageLocation": "./",
+    "installDirs": [],
+    "mode": "strict",
+    "serverCert": "",
     "downloadRetryCount": 0,
     "downloadRetryInterval": "5s",
     "broker": "tcp://localhost:1883",


### PR DESCRIPTION
[#176] Missing software update configuration properties

- provide a short description for 'installDirs', 'mode', and 'serverCert' properties
- add these properties to the template

Signed-off-by: Guzgunova Antonia <Antonia.Guzgunova@bosch.io>