### PR TITLE
Suite initializer must fail the test if thing configuration cannot be obtained

### DIFF
--- a/integration/util/suite.go
+++ b/integration/util/suite.go
@@ -61,7 +61,8 @@ func (suite *SuiteInitializer) Setup(t *testing.T) {
 	suite.MQTTClient = mqttClient
 	suite.ThingCfg, err = GetThingConfiguration(cfg, mqttClient)
 	if err != nil {
-		suite.TearDown()
+		defer suite.TearDown()
+		require.NoError(t, err, "cannot get thing configuration")
 	}
 }
 


### PR DESCRIPTION
[#183] Suite initializer must fail the test if thing configuration cannot be obtained

- bug fixed

Signed-off-by: Georgi Boyvalenkov <Georgi.Boyvalenkov@bosch.io>