### PR TITLE
Added integration testing util methods for WS unsubscribing and clean connection close

### DIFF
--- a/integration/util/config.go
+++ b/integration/util/config.go
@@ -19,15 +19,15 @@ import (
 // TestConfiguration is a common integration test configuration
 type TestConfiguration struct {
 	LocalBroker              string `env:"LOCAL_BROKER" envDefault:"tcp://localhost:1883"`
-	MqttQuiesceMs            int    `env:"MQTT_QUIESCE_MS" envDefault:"500"`
-	MqttAcknowledgeTimeoutMs int    `env:"MQTT_ACKNOWLEDGE_TIMEOUT_MS" envDefault:"3000"`
-	MqttConnectMs            int    `env:"MQTT_CONNECT_TIMEOUT_MS" envDefault:"30000"`
+	MQTTQuiesceMS            int    `env:"MQTT_QUIESCE_MS" envDefault:"500"`
+	MQTTAcknowledgeTimeoutMS int    `env:"MQTT_ACKNOWLEDGE_TIMEOUT_MS" envDefault:"3000"`
+	MQTTConnectMS            int    `env:"MQTT_CONNECT_TIMEOUT_MS" envDefault:"30000"`
 
 	DigitalTwinAPIAddress  string `env:"DIGITAL_TWIN_API_ADDRESS"`
 	DigitalTwinAPIUsername string `env:"DIGITAL_TWIN_API_USERNAME" envDefault:"ditto"`
 	DigitalTwinAPIPassword string `env:"DIGITAL_TWIN_API_PASSWORD" envDefault:"ditto"`
 
-	WsEventTimeoutMs int `env:"WS_EVENT_TIMEOUT_MS" envDefault:"30000"`
+	WSEventTimeoutMS int `env:"WS_EVENT_TIMEOUT_MS" envDefault:"30000"`
 }
 
 // MillisToDuration converts milliseconds to Duration

--- a/integration/util/mqtt_client.go
+++ b/integration/util/mqtt_client.go
@@ -36,7 +36,7 @@ func NewMQTTClient(cfg *TestConfiguration) (MQTT.Client, error) {
 	opts := MQTT.NewClientOptions().
 		AddBroker(cfg.LocalBroker).
 		SetClientID(uuid.New().String()).
-		SetConnectTimeout(MillisToDuration(cfg.MqttConnectMs)).
+		SetConnectTimeout(MillisToDuration(cfg.MQTTConnectMS)).
 		SetKeepAlive(keepAliveTimeout).
 		SetCleanSession(true).
 		SetAutoReconnect(true)
@@ -57,7 +57,7 @@ func SendMQTTMessage(cfg *TestConfiguration, client MQTT.Client, topic string, m
 		return err
 	}
 	token := client.Publish(topic, 1, false, payload)
-	timeout := MillisToDuration(cfg.MqttAcknowledgeTimeoutMs)
+	timeout := MillisToDuration(cfg.MQTTAcknowledgeTimeoutMS)
 	if !token.WaitTimeout(timeout) {
 		return errors.New("timeout while sending MQTT message")
 	}
@@ -87,7 +87,7 @@ func GetThingConfiguration(cfg *TestConfiguration, mqttClient MQTT.Client) (*Thi
 		}
 		ch <- result{&cfg, nil}
 	})
-	if !token.WaitTimeout(MillisToDuration(cfg.MqttAcknowledgeTimeoutMs)) {
+	if !token.WaitTimeout(MillisToDuration(cfg.MQTTAcknowledgeTimeoutMS)) {
 		return nil, errors.New("timeout subscribing to thing configuration response")
 	}
 	if token.Error() != nil {
@@ -97,7 +97,7 @@ func GetThingConfiguration(cfg *TestConfiguration, mqttClient MQTT.Client) (*Thi
 	defer mqttClient.Unsubscribe(topicThingCfgResponse)
 
 	token = mqttClient.Publish(topicThingCfgRequest, 1, false, "")
-	if !token.WaitTimeout(MillisToDuration(cfg.MqttAcknowledgeTimeoutMs)) {
+	if !token.WaitTimeout(MillisToDuration(cfg.MQTTAcknowledgeTimeoutMS)) {
 		return nil, errors.New("timeout publishing thing configuration request")
 	}
 	if token.Error() != nil {

--- a/integration/util/suite.go
+++ b/integration/util/suite.go
@@ -52,7 +52,7 @@ func (suite *SuiteInitializer) Setup(t *testing.T) {
 	}
 
 	if err != nil {
-		mqttClient.Disconnect(uint(cfg.MqttQuiesceMs))
+		mqttClient.Disconnect(uint(cfg.MQTTQuiesceMS))
 		require.NoError(t, err, "initialize ditto client")
 	}
 
@@ -69,5 +69,5 @@ func (suite *SuiteInitializer) Setup(t *testing.T) {
 // TearDown closes all connections
 func (suite *SuiteInitializer) TearDown() {
 	suite.DittoClient.Disconnect()
-	suite.MQTTClient.Disconnect(uint(suite.Cfg.MqttQuiesceMs))
+	suite.MQTTClient.Disconnect(uint(suite.Cfg.MQTTQuiesceMS))
 }

--- a/integration/util/web.go
+++ b/integration/util/web.go
@@ -30,6 +30,14 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+// SubscribeEventType is an event type description to be used with SubscribeForWSMessages.
+// It specifies the type of messages which should be listened for.
+type SubscribeEventType string
+
+// UnsubscribeEventType is an event type description to be used with UnsubscribeFromWSMessages.
+// It specifies the type of messages which should no longer be listened for.
+type UnsubscribeEventType string
+
 const (
 	thingURLTemplate                 = "%s/api/2/things/%s"
 	featureURLTemplate               = "%s/features/%s"
@@ -38,6 +46,18 @@ const (
 	featurePropertyPathTemplate      = "/features/%s/properties/%s"
 	featureMessageOutboxPathTemplate = "/features/%s/outbox/messages/%s"
 	featureMessageInboxPathTemplate  = "/features/%s/inbox/messages/%s"
+
+	// StartSendEvents specifies that events should be received.
+	StartSendEvents SubscribeEventType = "START-SEND-EVENTS"
+
+	// StopSendEvents specifies that events should no longer be received.
+	StopSendEvents UnsubscribeEventType = "STOP-SEND-EVENTS"
+
+	// StartSendMessages specifies that messages should be received.
+	StartSendMessages SubscribeEventType = "START-SEND-MESSAGES"
+
+	// StopSendMessages specifies that messages should no longer be received.
+	StopSendMessages UnsubscribeEventType = "STOP-SEND-MESSAGES"
 )
 
 // SendDigitalTwinRequest sends а new HTTP request to the Ditto REST API
@@ -131,20 +151,20 @@ func sendMessageAndAwaitAck(cfg *TestConfiguration, conn *websocket.Conn, msg st
 }
 
 // SubscribeForWSMessages subscribes for the messages that are sent from a WebSocket session and awaits confirmation response.
-func SubscribeForWSMessages(cfg *TestConfiguration, conn *websocket.Conn, eventType string, filter string) error {
+func SubscribeForWSMessages(cfg *TestConfiguration, conn *websocket.Conn, eventType SubscribeEventType, filter string) error {
 	var msg string
 	if len(filter) > 0 {
 		msg = fmt.Sprintf("%s?filter=%s", eventType, filter)
 	} else {
-		msg = eventType
+		msg = string(eventType)
 	}
-	return sendMessageAndAwaitAck(cfg, conn, msg, eventType)
+	return sendMessageAndAwaitAck(cfg, conn, msg, string(eventType))
 }
 
 // UnsubscribeFromWSMessages unsubscribes from the messages that are sent from a WebSocket session
 // and awaits confirmation response.
-func UnsubscribeFromWSMessages(cfg *TestConfiguration, ws *websocket.Conn, eventType string) error {
-	return sendMessageAndAwaitAck(cfg, ws, eventType, eventType)
+func UnsubscribeFromWSMessages(cfg *TestConfiguration, ws *websocket.Conn, eventType UnsubscribeEventType) error {
+	return sendMessageAndAwaitAck(cfg, ws, string(eventType), string(eventType))
 }
 
 // WaitForWSMessage waits for received a specific message from a WebSocket session or timeout expires

--- a/integration/util/web.go
+++ b/integration/util/web.go
@@ -149,7 +149,7 @@ func UnsubscribeFromWSMessages(cfg *TestConfiguration, ws *websocket.Conn, event
 
 // WaitForWSMessage waits for received a specific message from a WebSocket session or timeout expires
 func WaitForWSMessage(cfg *TestConfiguration, ws *websocket.Conn, expectedMessage string) error {
-	deadline := time.Now().Add(MillisToDuration(cfg.WsEventTimeoutMs))
+	deadline := time.Now().Add(MillisToDuration(cfg.WSEventTimeoutMS))
 	if err := ws.SetDeadline(deadline); err != nil {
 		return fmt.Errorf("unable to set deadline to websocket: %v", err)
 	}
@@ -170,7 +170,7 @@ func WaitForWSMessage(cfg *TestConfiguration, ws *websocket.Conn, expectedMessag
 
 // ProcessWSMessages processes messages for the satisfied condition from the WebSocket session or timeout expires
 func ProcessWSMessages(cfg *TestConfiguration, ws *websocket.Conn, process func(*protocol.Envelope) (bool, error)) error {
-	timeout := MillisToDuration(cfg.WsEventTimeoutMs)
+	timeout := MillisToDuration(cfg.WSEventTimeoutMS)
 	deadline := time.Now().Add(timeout)
 	if err := ws.SetDeadline(deadline); err != nil {
 		return fmt.Errorf("unable to set deadline to websocket: %v", err)
@@ -205,7 +205,7 @@ func ProcessWSMessages(cfg *TestConfiguration, ws *websocket.Conn, process func(
 // Disconnect calls Close() on the WebSocket connection.
 // Then we wait until the connection is fully closed or the timeout expires.
 func Disconnect(cfg *TestConfiguration, ws *websocket.Conn) error {
-	deadline := time.Now().Add(MillisToDuration(cfg.WsEventTimeoutMs))
+	deadline := time.Now().Add(MillisToDuration(cfg.WSEventTimeoutMS))
 	if err := ws.SetDeadline(deadline); err != nil {
 		return fmt.Errorf("unable to set deadline to websocket: %v", err)
 	}


### PR DESCRIPTION
[#185] Create integration test util methods for unsubscribing from WS messages, and for clean closing of WS connections

- UnsubscribeFromWSMessages
- Disconnect

Signed-off-by: Dimiter Georgiev <dimiter.georgiev@bosch.io>