### PR TITLE
Document container management MQTTS configuration properties

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,3 +1,4 @@
 public/
 node_modules
 resources/
+.hugo_build.lock

--- a/web/site/content/docs/references/containers/container-manager-config.md
+++ b/web/site/content/docs/references/containers/container-manager-config.md
@@ -68,6 +68,10 @@ To control all aspects of the container manager behavior.
 | acknowledge_timeout | int | 15000 | Acknowledge timeout in milliseconds for the MQTT requests |
 | subscribe_timeout | int | 15000 | Subscribe timeout in milliseconds for the MQTT requests |
 | unsubscribe_timeout | int | 5000 | Unsubscribe timeout in milliseconds for the MQTT requests |
+| **Digital twin - TLS** | | | |
+| root_ca | string | | PEM encoded CA certificates file |
+| client_cert | string | | PEM encoded certificate file to authenticate to the MQTT server/broker |
+| client_key | string | | PEM encoded unencrypted private key file to authenticate to the MQTT server/broker |
 | **Logging** | | | |
 | log_file | string | log/container-management.log | Path to the file where the container manager's log messages are written |
 | log_level | string | INFO | All log messages at this or a higher level will be logged, the log levels in descending order are: ERROR, WARN, INFO, DEBUG and TRACE |
@@ -174,7 +178,12 @@ Be aware that in the registry configuration the host (used as a key) has to be s
             "connect_timeout": 30000,
             "acknowledge_timeout": 15000,
             "subscribe_timeout": 15000,
-            "unsubscribe_timeout": 5000
+            "unsubscribe_timeout": 5000,
+            "transport": {
+                "root_ca": "",
+                "client_cert": "",
+                "client_key": ""
+            }
         }
     },
     "log": {

--- a/web/site/content/docs/references/containers/container-manager-config.md
+++ b/web/site/content/docs/references/containers/container-manager-config.md
@@ -68,7 +68,7 @@ To control all aspects of the container manager behavior.
 | acknowledge_timeout | int | 15000 | Acknowledge timeout in milliseconds for the MQTT requests |
 | subscribe_timeout | int | 15000 | Subscribe timeout in milliseconds for the MQTT requests |
 | unsubscribe_timeout | int | 5000 | Unsubscribe timeout in milliseconds for the MQTT requests |
-| **Digital twin - TLS** | | | |
+| **Digital twin - connectivity - TLS** | | | |
 | root_ca | string | | PEM encoded CA certificates file |
 | client_cert | string | | PEM encoded certificate file to authenticate to the MQTT server/broker |
 | client_key | string | | PEM encoded unencrypted private key file to authenticate to the MQTT server/broker |


### PR DESCRIPTION
[#192] Document container management MQTTS configuration properties in the local communication

- Documentation for the MQTTS configuration is added
- .hugo_build.lock file is added to the .gitignore

Signed-off-by: Kristiyan Gostev <kristiyan.gostev@bosch.io>