### PR TITLE
Document ALPN support

### DIFF
--- a/web/site/content/docs/references/connectivity/suite-connector-config.md
+++ b/web/site/content/docs/references/connectivity/suite-connector-config.md
@@ -15,6 +15,7 @@ To control all aspects of the suite connector behavior.
 | provisioningFile | string ​| provisioning.json | Path to the provisioning file, if {{% relrefn "dmp" %}}Bosch IoT Device Management{{% /relrefn %}} is in use |
 | **Remote connectivity** | | | |
 | address | string | mqtts://mqtt.bosch-iot-hub.com:8883 | Address of the MQTT endpoint that the suite connector will connect for the remote communication, the format is: `scheme://host:port` |
+| alpn | string[] | | TLS application layer protocol negotiation options space separated for cloud access |
 | deviceId | string | | Device unique identifier |
 | authId | string | | Authentication unique identifier that is a part of the credentials |
 | tenantId | string | | Tenant unique identifier that the device belongs to |
@@ -76,6 +77,7 @@ Be aware that some combinations may be incompatible
 {
     "provisioningFile": "provisioning.json",
     "address": "mqtts://mqtt.bosch-iot-hub.com:8883",
+    "alpn" : [],
     "deviceId": "",
     "authId": "",
     "tenantId": "",


### PR DESCRIPTION
[#217] TLS ALPN extension setting is needed to connect to cloud MQTT brokers through firewalls on port 443 and proxies which support HTTP/2