### PR TITLE
Change Install Eclipse Kanto links to M3 version in documentation.

### DIFF
--- a/web/site/content/docs/getting-started/install.md
+++ b/web/site/content/docs/getting-started/install.md
@@ -21,8 +21,8 @@ at <a href="https://github.com/eclipse-kanto/kanto/releases" target="_blank">the
 Download and install it via executing the following (adjusted to your package name):
 
 ```shell
-wget https://github.com/eclipse-kanto/kanto/releases/download/v0.1.0-M2/kanto_0.1.0-M2_linux_x86_64.deb && \
-sudo apt install ./kanto_0.1.0-M2_linux_x86_64.deb
+wget https://github.com/eclipse-kanto/kanto/releases/download/v0.1.0-M3/kanto_0.1.0-M3_linux_x86_64.deb && \
+sudo apt install ./kanto_0.1.0-M3_linux_x86_64.deb
 ```
 
 ### Verify


### PR DESCRIPTION
[#234] Change Install Eclipse Kanto links to M3 version in documentation.

Signed-off-by: Daniel Milchev <fixed-term.daniel.milchev@bosch.io>