### PR TITLE
Change the update manager binary name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,13 @@ jobs:
           path: ${{ env.BUILD_TMP }}/system-metrics
           ref: ${{ github.ref }}
           token: ${{ secrets.WF_AUTH }}
+      - name: Checkout update-manager
+        uses: actions/checkout@v2
+        with:
+          repository: eclipse-kanto/update-manager
+          path: ${{ env.BUILD_TMP }}/update-manager
+          ref: ${{ github.ref }}
+          token: ${{ secrets.WF_AUTH }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -436,7 +436,7 @@ builds:
   - id: build-update-manager
     dir: ./build-tmp/update-manager
     main:  ./cmd/update-manager
-    binary: update-manager/update-manager
+    binary: update-manager/kanto-update-manager
     goos:
       - linux
     goarch:
@@ -459,7 +459,7 @@ builds:
   - id: build-update-manager-pkg
     dir: ./build-tmp/update-manager
     main:  ./cmd/update-manager
-    binary: update-manager
+    binary: kanto-update-manager
     goos:
       - linux
     goarch:
@@ -481,7 +481,7 @@ builds:
     mod_timestamp: '{{ .CommitTimestamp }}'
 archives:
   - id: kanto-archive-all
-    name_template: '{{ .ProjectName }}_{{ .Version }}_linux_{{ if .Amd64 }}x86_64{{ else if .Arm }}armv7{{ else }}{{ .Runtime.Goarch }}{{ end }}'
+    name_template: '{{ .ProjectName }}_{{ .Version }}_linux_{{ if .Amd64 }}x86_64{{ else if .Arm }}armv7{{ else }}{{ .Arch }}{{ end }}'
     builds:
       - build-suite-connector
       - build-container-management
@@ -561,7 +561,7 @@ archives:
           mode: 0644
       # update-manager additional files
       - src: ./build-tmp/update-manager/NOTICE.md
-        dst: update-manager
+        dst: kanto-update-manager
         strip_parent: true
         info:
           mode: 0644
@@ -578,7 +578,7 @@ nfpms:
       - build-system-metrics-pkg
       - build-update-manager-pkg
     bindir: /usr/bin
-    file_name_template: '{{ .ProjectName }}_{{ .Version }}_linux_{{ if .Amd64 }}x86_64{{ else if .Arm }}armv7{{ else }}{{ .Runtime.Goarch }}{{ end }}'
+    file_name_template: '{{ .ProjectName }}_{{ .Version }}_linux_{{ if .Amd64 }}x86_64{{ else if .Arm }}armv7{{ else }}{{ .Arch }}{{ end }}'
     maintainer: Contributors to the Eclipse Foundation, Kanto Project <kanto-dev@eclipse.org>
     description: |-
       Eclipse Kanto™ is a modular IoT edge software that enables devices for IoT with all essentials
@@ -871,20 +871,20 @@ nfpms:
           mode: 0644
         packager: rpm
       - src: ./build-tmp/update-manager/resources/config.json
-        dst: /etc/update-manager/config.json
+        dst: /etc/kanto-update-manager/config.json
         type: config
         file_info:
           mode: 0644
       - src: ./build-tmp/update-manager/NOTICE.md
-        dst: /usr/share/doc/update-manager/NOTICE.md
+        dst: /usr/share/doc/kanto-update-manager/NOTICE.md
         file_info:
           mode: 0644
       - src: ./build-tmp/update-manager/README.md
-        dst: /usr/share/doc/update-manager/README.md
+        dst: /usr/share/doc/kanto-update-manager/README.md
         file_info:
           mode: 0644
       - src: ./build-tmp/update-manager/LICENSE
-        dst: /usr/share/doc/update-manager/LICENSE
+        dst: /usr/share/doc/kanto-update-manager/LICENSE
         file_info:
           mode: 0644
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -436,7 +436,7 @@ builds:
   - id: build-update-manager
     dir: ./build-tmp/update-manager
     main:  ./cmd/update-manager
-    binary: update-manager/kanto-update-manager
+    binary: kanto-update-manager/kanto-update-manager
     goos:
       - linux
     goarch:
@@ -861,12 +861,12 @@ nfpms:
           mode: 0644
       # update-manager additional resources
       - src: ./build-tmp/update-manager/resources/update-manager.service
-        dst: /etc/systemd/system/update-manager.service
+        dst: /etc/systemd/system/kanto-update-manager.service
         file_info:
           mode: 0644
         packager: deb
       - src: ./build-tmp/update-manager/resources/update-manager.service
-        dst: /usr/lib/systemd/system/update-manager.service
+        dst: /usr/lib/systemd/system/kanto-update-manager.service
         file_info:
           mode: 0644
         packager: rpm

--- a/build/80-kanto.preset
+++ b/build/80-kanto.preset
@@ -11,4 +11,4 @@ enable file-upload.service
 enable software-update.service
 enable file-backup.service
 enable system-metrics.service
-enable update-manager.service
+enable kanto-update-manager.service

--- a/build/postinst
+++ b/build/postinst
@@ -101,17 +101,17 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
     fi
 
         # This will only remove masks created by d-s-h on package removal.
-    deb-systemd-helper unmask 'update-manager.service' >/dev/null || true
+    deb-systemd-helper unmask 'kanto-update-manager.service' >/dev/null || true
 
     # was-enabled defaults to true, so new installations run enable.
-    if deb-systemd-helper --quiet was-enabled 'update-manager.service'; then
+    if deb-systemd-helper --quiet was-enabled 'kanto-update-manager.service'; then
         # Enables the unit on first installation, creates new
         # symlinks on upgrades if the unit file has changed.
-        deb-systemd-helper enable 'update-manager.service' >/dev/null || true
+        deb-systemd-helper enable 'kanto-update-manager.service' >/dev/null || true
     else
         # Update the statefile to add new symlinks (if any), which need to be
         # cleaned up on purge. Also remove old symlinks.
-        deb-systemd-helper update-state 'update-manager.service' >/dev/null || true
+        deb-systemd-helper update-state 'kanto-update-manager.service' >/dev/null || true
     fi
     
 fi
@@ -133,7 +133,7 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
         deb-systemd-invoke $_dh_action 'software-update.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'file-backup.service' >/dev/null || true
         deb-systemd-invoke $_dh_action 'system-metrics.service' >/dev/null || true
-        deb-systemd-invoke $_dh_action 'update-manager.service' >/dev/null || true
+        deb-systemd-invoke $_dh_action 'kanto-update-manager.service' >/dev/null || true
     fi
 fi
 # End automatically added section

--- a/build/postinst_rpm
+++ b/build/postinst_rpm
@@ -18,7 +18,7 @@ if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
     /usr/lib/systemd/systemd-update-helper install-system-units software-update.service || :
     /usr/lib/systemd/systemd-update-helper install-system-units file-backup.service || :
     /usr/lib/systemd/systemd-update-helper install-system-units system-metrics.service || :
-    /usr/lib/systemd/systemd-update-helper install-system-units update-manager.service || :
+    /usr/lib/systemd/systemd-update-helper install-system-units kanto-update-manager.service || :
 
     # Start the Kanto services if enabled
     if [ -d /run/systemd/system ]; then
@@ -30,6 +30,6 @@ if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
         systemctl is-enabled -q software-update.service && systemctl start software-update.service >/dev/null || :
         systemctl is-enabled -q file-backup.service && systemctl start file-backup.service >/dev/null || :
         systemctl is-enabled -q system-metrics.service && systemctl start system-metrics.service >/dev/null || :
-        systemctl is-enabled -q update-manager.service && systemctl start update-manager.service >/dev/null || :
+        systemctl is-enabled -q kanto-update-manager.service && systemctl start kanto-update-manager.service >/dev/null || :
     fi
 fi

--- a/build/postrm
+++ b/build/postrm
@@ -6,7 +6,7 @@ fi
 # Automatically added by dh_systemd_enable/12.1.1bv2019.0b1
 if [ "$1" = "remove" ]; then
     if [ -x "/usr/bin/deb-systemd-helper" ]; then
-        deb-systemd-helper mask 'update-manager.service' >/dev/null || true
+        deb-systemd-helper mask 'kanto-update-manager.service' >/dev/null || true
         deb-systemd-helper mask 'system-metrics.service' >/dev/null || true
         deb-systemd-helper mask 'file-backup.service' >/dev/null || true
         deb-systemd-helper mask 'software-update.service' >/dev/null || true
@@ -20,8 +20,8 @@ fi
 
 if [ "$1" = "purge" ]; then
     if [ -x "/usr/bin/deb-systemd-helper" ]; then
-        deb-systemd-helper purge 'update-manager.service' >/dev/null || true
-        deb-systemd-helper unmask 'update-manager.service' >/dev/null || true
+        deb-systemd-helper purge 'kanto-update-manager.service' >/dev/null || true
+        deb-systemd-helper unmask 'kanto-update-manager.service' >/dev/null || true
         deb-systemd-helper purge 'system-metrics.service' >/dev/null || true
         deb-systemd-helper unmask 'system-metrics.service' >/dev/null || true
         deb-systemd-helper purge 'file-backup.service' >/dev/null || true

--- a/build/postrm_rpm
+++ b/build/postrm_rpm
@@ -10,7 +10,7 @@ if [ $1 -ge 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
     /usr/lib/systemd/systemd-update-helper mark-restart-system-units software-update.service || :
     /usr/lib/systemd/systemd-update-helper mark-restart-system-units file-backup.service || :
     /usr/lib/systemd/systemd-update-helper mark-restart-system-units system-metrics.service || :
-    /usr/lib/systemd/systemd-update-helper mark-restart-system-units update-manager.service || :
+    /usr/lib/systemd/systemd-update-helper mark-restart-system-units kanto-update-manager.service || :
 fi
 
 if [ $1 -eq 0 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then

--- a/build/prerm
+++ b/build/prerm
@@ -1,5 +1,5 @@
 if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
-    deb-systemd-invoke stop 'update-manager.service' >/dev/null || true
+    deb-systemd-invoke stop 'kanto-update-manager.service' >/dev/null || true
     deb-systemd-invoke stop 'system-metrics.service' >/dev/null || true
     deb-systemd-invoke stop 'file-backup.service' >/dev/null || true
     deb-systemd-invoke stop 'software-update.service' >/dev/null || true

--- a/build/prerm_rpm
+++ b/build/prerm_rpm
@@ -2,7 +2,7 @@ if [ $1 -eq 0 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
     # Package removal, not upgrade
 
     # Remove the Kanto services, including ones that are usually disabled by default
-    /usr/lib/systemd/systemd-update-helper remove-system-units update-manager.service || :
+    /usr/lib/systemd/systemd-update-helper remove-system-units kanto-update-manager.service || :
     /usr/lib/systemd/systemd-update-helper remove-system-units system-metrics.service || :
     /usr/lib/systemd/systemd-update-helper remove-system-units file-backup.service || :
     /usr/lib/systemd/systemd-update-helper remove-system-units software-update.service || :


### PR DESCRIPTION
 [#262] Change the update manager binary name
 - rename update-manager binary to kanto-update-manager
 - change other colliding path by adding 'kanto-' prefix
 - leave the update-manager.service with the same name
 - add update-manager in the release workflow
 - fix name templates for arm64
 
 Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>