### PR TITLE
Modified install_ctrd.sh to support Debian 12

### DIFF
--- a/quickstart/install_ctrd.sh
+++ b/quickstart/install_ctrd.sh
@@ -44,6 +44,9 @@ get_distribution_version() {
     debian|raspbian)
         dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
         case "$dist_version" in
+            12)
+                dist_version="bookworm"
+            ;;
             11)
                 dist_version="bullseye"
             ;;


### PR DESCRIPTION
[#313] Added "bookworm" version to install_ctrd.sh 

Signed-off-by: Daniel Milchev [fixed-term.daniel.milchev@bosch.io](mailto:fixed-term.daniel.milchev@bosch.io)